### PR TITLE
SCALA-106 - example App to demonstrate sbt-assembly plugin to create Fat JAR

### DIFF
--- a/scala-sbt/README.md
+++ b/scala-sbt/README.md
@@ -1,5 +1,3 @@
 ## Scala SBT tutorials
 
-This module contains articles about Scala's SBT features 
-
-- [Creating a Fat JAR using SBT](https://www.baeldung.com/scala/creating-a-fat-jar-using-sbt/)
+This module contains articles about Scala's SBT features

--- a/scala-sbt/README.md
+++ b/scala-sbt/README.md
@@ -1,0 +1,5 @@
+## Scala SBT tutorials
+
+This module contains articles about Scala's SBT features 
+
+- [Creating a Fat JAR using SBT](https://www.baeldung.com/scala/creating-a-fat-jar-using-sbt/)

--- a/scala-sbt/build.sbt
+++ b/scala-sbt/build.sbt
@@ -1,0 +1,23 @@
+lazy val root = (project in file(".")).
+  settings(
+    name := "scala-sbt",
+    version := "1.0",
+    scalaVersion := "2.12.7",
+    mainClass in Compile := Some("com.baeldung.scala.sbt.SbtAssemblyExample"),
+    mainClass in assembly := Some("com.baeldung.scala.sbt.SbtAssemblyExample")
+  )
+
+val sparkVersion = "2.4.4"
+
+libraryDependencies += "org.apache.spark" %% "spark-core" % sparkVersion % "provided"
+libraryDependencies += "org.apache.spark" %% "spark-sql" % sparkVersion
+
+assemblyJarName in assembly := "baeldung-scala-sbt-assembly-fatjar-1.0.jar"
+
+// META-INF discarding
+assemblyMergeStrategy in assembly := {
+ case PathList("META-INF", xs @ _*) => MergeStrategy.discard
+ case x => MergeStrategy.first
+}
+
+

--- a/scala-sbt/project/build.properties
+++ b/scala-sbt/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/scala-sbt/project/plugins.sbt
+++ b/scala-sbt/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")

--- a/scala-sbt/src/main/scala/com/baeldung/scala/sbt/SbtAssemblyExample.scala
+++ b/scala-sbt/src/main/scala/com/baeldung/scala/sbt/SbtAssemblyExample.scala
@@ -1,0 +1,9 @@
+package com.baeldung.scala.sbt
+
+import org.apache.spark.sql.SparkSession
+
+object SbtAssemblyExample extends App {
+
+  print("Hello.. This is an example App to demonstrate sbt-assembly plugin to create Fat JAR")
+
+}


### PR DESCRIPTION
SCALA-106 - example App to demonstrate sbt-assembly plugin to create Fat JAR

I have added a new module "scala-sbt" to the project directory, as I didn't want to alter the existing build.sbt file for the purpose of this tutorial.
There are few more open items on JIRA related to SBT which could go under this module.