### PR TITLE
Fixed many of the warnings after scala 2.13 upgrade

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -134,12 +134,13 @@ lazy val scala_core_collections = (project in file("scala-core-collections"))
     )
   )
 
-lazy val scala_core_collections_2 = (project in file("scala-core-collections-2"))
-  .settings(
-    name := "scala-core-collections-2",
-    libraryDependencies +=
-      "org.scalatest" %% "scalatest" % "3.2.14" % Test
-  )
+lazy val scala_core_collections_2 =
+  (project in file("scala-core-collections-2"))
+    .settings(
+      name := "scala-core-collections-2",
+      libraryDependencies +=
+        "org.scalatest" %% "scalatest" % "3.2.14" % Test
+    )
 
 lazy val scala_test = (project in file("scala-test"))
   .settings(
@@ -330,11 +331,11 @@ lazy val scala_libraries_4 = (project in file("scala-libraries-4"))
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
       "org.tpolecat" %% "skunk-core" % "0.3.2"
     ),
-     libraryDependencies ++= Seq(
+    libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-core" % sparkVersion,
       "org.apache.spark" %% "spark-sql" % sparkVersion
     ),
-    scalacOptions += "-Xasync"
+    //scalacOptions += "-Xasync"
   )
 
 lazy val scala_strings = (project in file("scala-strings"))

--- a/build.sbt
+++ b/build.sbt
@@ -335,7 +335,7 @@ lazy val scala_libraries_4 = (project in file("scala-libraries-4"))
       "org.apache.spark" %% "spark-core" % sparkVersion,
       "org.apache.spark" %% "spark-sql" % sparkVersion
     ),
-    //scalacOptions += "-Xasync"
+    scalacOptions += "-Xasync"
   )
 
 lazy val scala_strings = (project in file("scala-strings"))

--- a/build.sbt
+++ b/build.sbt
@@ -187,7 +187,6 @@ lazy val scala_akka_2 = (project in file("scala-akka-2"))
   .enablePlugins(AkkaGrpcPlugin)
   .settings(
     name := "scala-akka-2",
-    scalaVersion := "2.13.10",
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-actor-typed" % "2.6.19",
       "com.typesafe.akka" %% "akka-http" % "10.2.10",
@@ -236,6 +235,9 @@ val monixVersion = "3.4.0"
 val elastic4sVersion = "7.16.0"
 val sparkVersion = "3.2.1"
 
+val sparkCoreDep = "org.apache.spark" %% "spark-core" % sparkVersion
+val sparkSqlDep = "org.apache.spark" %% "spark-sql" % sparkVersion
+
 lazy val scala_libraries_2 = (project in file("scala-libraries-2"))
   .settings(
     name := "scala-libraries",
@@ -282,8 +284,8 @@ lazy val scala_libraries_3 = (project in file("scala-libraries-3"))
     name := "scala-libraries",
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % Test,
     libraryDependencies ++= Seq(
-      "org.apache.spark" %% "spark-core" % sparkVersion,
-      "org.apache.spark" %% "spark-sql" % sparkVersion
+      sparkSqlDep,
+      sparkCoreDep
     ),
     libraryDependencies ++= Seq(
       "org.http4s" %% "http4s-dsl" % http4sVersion,
@@ -324,7 +326,9 @@ lazy val scala_libraries_4 = (project in file("scala-libraries-4"))
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-async" % "1.0.1",
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
-      "org.tpolecat" %% "skunk-core" % "0.3.2"
+      "org.tpolecat" %% "skunk-core" % "0.3.2",
+      sparkSqlDep,
+      sparkCoreDep
     ),
     scalacOptions += "-Xasync"
   )
@@ -404,8 +408,6 @@ lazy val scala212 = (project in file("scala212"))
     scalaVersion := "2.12.17",
     name := "scala212",
     libraryDependencies ++= Seq(
-      scalaTest,
-      "org.apache.spark" %% "spark-core" % sparkVersion,
-      "org.apache.spark" %% "spark-sql" % sparkVersion
+      scalaTest
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -260,12 +260,12 @@ lazy val scala_libraries_2 = (project in file("scala-libraries-2"))
       "io.monix" %% "monix" % monixVersion
     ),
     dependencyOverrides := Seq(
-      "com.typesafe.akka" %% "akka-protobuf-v3" % "2.6.16",
-      "com.typesafe.akka" %% "akka-stream" % "2.6.16",
-      "com.typesafe.akka" %% "akka-serialization-jackson" % "2.6.16"
+      "com.typesafe.akka" %% "akka-protobuf-v3" % "2.6.19",
+      "com.typesafe.akka" %% "akka-stream" % "2.6.19",
+      "com.typesafe.akka" %% "akka-serialization-jackson" % "2.6.19"
     ),
     libraryDependencies ++= Seq(
-      "com.typesafe.akka" %% "akka-actor-testkit-typed" % "2.6.16" % Test,
+      "com.typesafe.akka" %% "akka-actor-testkit-typed" % "2.6.19" % Test,
       "org.scalatest" %% "scalatest" % "3.1.4" % Test,
       "org.scalacheck" %% "scalacheck" % "1.14.1" % Test,
       "com.lihaoyi" %% "requests" % "0.6.9"

--- a/build.sbt
+++ b/build.sbt
@@ -238,7 +238,6 @@ val sparkVersion = "3.2.1"
 
 lazy val scala_libraries_2 = (project in file("scala-libraries-2"))
   .settings(
-    scalaVersion := "2.12.15",
     name := "scala-libraries",
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % Test,
     libraryDependencies ++= Seq(
@@ -252,15 +251,11 @@ lazy val scala_libraries_2 = (project in file("scala-libraries-2"))
       "com.beachape" %% "enumeratum" % "1.7.0"
     ),
     libraryDependencies ++= Seq(
-      "com.typesafe.play" %% "play-slick" % "5.0.0",
+      "com.typesafe.play" %% "play-slick" % "5.1.0",
       "org.postgresql" % "postgresql" % "42.2.12"
     ),
     libraryDependencies ++= Seq(
       "io.monix" %% "monix" % monixVersion
-    ),
-    libraryDependencies ++= Seq(
-      "org.apache.spark" %% "spark-core" % sparkVersion,
-      "org.apache.spark" %% "spark-sql" % sparkVersion
     ),
     dependencyOverrides := Seq(
       "com.typesafe.akka" %% "akka-protobuf-v3" % "2.6.16",
@@ -330,10 +325,6 @@ lazy val scala_libraries_4 = (project in file("scala-libraries-4"))
       "org.scala-lang.modules" %% "scala-async" % "1.0.1",
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
       "org.tpolecat" %% "skunk-core" % "0.3.2"
-    ),
-    libraryDependencies ++= Seq(
-      "org.apache.spark" %% "spark-core" % sparkVersion,
-      "org.apache.spark" %% "spark-sql" % sparkVersion
     ),
     scalacOptions += "-Xasync"
   )
@@ -413,6 +404,8 @@ lazy val scala212 = (project in file("scala212"))
     scalaVersion := "2.12.17",
     name := "scala212",
     libraryDependencies ++= Seq(
-      scalaTest
+      scalaTest,
+      "org.apache.spark" %% "spark-core" % sparkVersion,
+      "org.apache.spark" %% "spark-sql" % sparkVersion
     )
   )

--- a/cats-effects/src/main/scala/com/baeldung/scala/resources/ResourceHandling.scala
+++ b/cats-effects/src/main/scala/com/baeldung/scala/resources/ResourceHandling.scala
@@ -1,12 +1,9 @@
 package com.baeldung.scala.resources
 
-import cats.effect.IO
-import java.io.File
-import scala.io.Source
-import cats.effect.IOApp
-import scala.io.BufferedSource
+import cats.effect.{IO, IOApp, Resource}
+
 import java.io.FileWriter
-import cats.effect.Resource
+import scala.io.Source
 
 object ResourceHandling extends IOApp.Simple {
 

--- a/play-scala/async-tasks/build.sbt
+++ b/play-scala/async-tasks/build.sbt
@@ -5,6 +5,6 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.13.2"
+scalaVersion := "2.13.10"
 
 libraryDependencies += guice

--- a/play-scala/caching-in-play/build.sbt
+++ b/play-scala/caching-in-play/build.sbt
@@ -5,7 +5,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.13.3"
+scalaVersion := "2.13.10"
 
 libraryDependencies += guice
 libraryDependencies += caffeine

--- a/play-scala/configuration-access/build.sbt
+++ b/play-scala/configuration-access/build.sbt
@@ -5,7 +5,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.13.3"
+scalaVersion := "2.13.10"
 
 libraryDependencies += guice
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test

--- a/play-scala/custom-error-handling/build.sbt
+++ b/play-scala/custom-error-handling/build.sbt
@@ -5,7 +5,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.13.2"
+scalaVersion := "2.13.10"
 
 libraryDependencies += guice
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test

--- a/play-scala/dependency-injection/build.sbt
+++ b/play-scala/dependency-injection/build.sbt
@@ -4,7 +4,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.10"
 
 libraryDependencies += guice
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test

--- a/play-scala/introduction-to-play/build.sbt
+++ b/play-scala/introduction-to-play/build.sbt
@@ -4,6 +4,6 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.13.2"
+scalaVersion := "2.13.10"
 
 libraryDependencies += guice libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test

--- a/play-scala/play-templates/build.sbt
+++ b/play-scala/play-templates/build.sbt
@@ -5,7 +5,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.13.2"
+scalaVersion := "2.13.10"
 
 libraryDependencies += guice
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test

--- a/play-scala/rest-api/build.sbt
+++ b/play-scala/rest-api/build.sbt
@@ -5,7 +5,7 @@ version := "1.0-SNAPSHOT"
 
 lazy val root = (project in file(".")).enablePlugins(PlayScala)
 
-scalaVersion := "2.13.2"
+scalaVersion := "2.13.10"
 
 libraryDependencies += guice
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "5.0.0" % Test

--- a/scala-akka-2/src/main/scala/com/baeldung/scala/akka/http/MovieService.scala
+++ b/scala-akka-2/src/main/scala/com/baeldung/scala/akka/http/MovieService.scala
@@ -1,7 +1,6 @@
 package com.baeldung.scala.akka.http
-import scala.concurrent.Future
-import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 case class Movie(id: Int, name: String, length: Int)
 

--- a/scala-akka/src/main/scala/com/baeldung/scala/akka/alpakka/AlpakkaMongoIntegration.scala
+++ b/scala-akka/src/main/scala/com/baeldung/scala/akka/alpakka/AlpakkaMongoIntegration.scala
@@ -1,7 +1,5 @@
 package com.baeldung.scala.akka.alpakka
 
-import java.nio.file.FileSystems
-
 import akka.NotUsed
 import akka.stream.alpakka.mongodb.scaladsl.MongoSink
 import akka.stream.scaladsl.Source

--- a/scala-akka/src/main/scala/com/baeldung/scala/akka/scheduler/Greetings.scala
+++ b/scala-akka/src/main/scala/com/baeldung/scala/akka/scheduler/Greetings.scala
@@ -8,6 +8,6 @@ final case class Greeted(msg: String)
 class Greetings extends Actor {
   override def receive: Receive = {
     case greet: Greet =>
-      sender ! Greeted(s"${greet.by}: Hello, ${greet.to}")
+      sender() ! Greeted(s"${greet.by}: Hello, ${greet.to}")
   }
 }

--- a/scala-akka/src/main/scala/com/baeldung/scala/akka/stopping/MessageProcessorActor.scala
+++ b/scala-akka/src/main/scala/com/baeldung/scala/akka/stopping/MessageProcessorActor.scala
@@ -1,10 +1,6 @@
 package com.baeldung.scala.akka.stopping
 
 import akka.actor.Actor
-import akka.actor.ActorSystem
-import akka.actor.Props
-import akka.actor.PoisonPill
-import akka.actor.DeadLetter
 
 object MessageProcessorActor {
   trait Message
@@ -19,7 +15,7 @@ class MessageProcessorActor extends Actor {
 
   override def receive: Receive = {
     case msg: MessageProcessorActor.Greet =>
-      sender ! MessageProcessorActor.Reply("Hey, " + msg.msg)
+      sender() ! MessageProcessorActor.Reply("Hey, " + msg.msg)
   }
 
 }

--- a/scala-akka/src/main/scala/com/baeldung/scala/akka/supervision/SupervisionApplication.scala
+++ b/scala-akka/src/main/scala/com/baeldung/scala/akka/supervision/SupervisionApplication.scala
@@ -10,7 +10,7 @@ import com.baeldung.scala.akka.supervision.SupervisionApplication.Filesystem.{Fs
 import com.baeldung.scala.akka.supervision.SupervisionApplication.WebServer.Request
 
 import scala.concurrent.duration.DurationInt
-import scala.util.{Failure, Random, Success, Try}
+import scala.util.{Failure, Success, Try}
 
 object SupervisionApplication {
 

--- a/scala-core-2/src/main/scala/com/baeldung/scala/concurrency/FutureAndPromise.scala
+++ b/scala-core-2/src/main/scala/com/baeldung/scala/concurrency/FutureAndPromise.scala
@@ -53,7 +53,7 @@ object ScalaAndPromise {
     } yield User(name, email, hashedPassword, avatar)
 
   def runByPromise[T](block: => T)(implicit ec: ExecutionContext): Future[T] = {
-    val p = Promise[T]
+    val p = Promise[T]()
     ec.execute { () =>
       try {
         p.success(block)

--- a/scala-core-2/src/main/scala/com/baeldung/scala/exceptionhandling/ExceptionHandling.scala
+++ b/scala-core-2/src/main/scala/com/baeldung/scala/exceptionhandling/ExceptionHandling.scala
@@ -21,7 +21,7 @@ object ExceptionHandling {
     try {
       divide(a, 0)
     } catch {
-      case e: DivideByZero => null
+      case _: DivideByZero => null
     } finally {
       println("Finished")
     }

--- a/scala-core-3/src/main/scala/com/baeldung/scala/await/AwaitFuture.scala
+++ b/scala-core-3/src/main/scala/com/baeldung/scala/await/AwaitFuture.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.await
 
-import scala.concurrent.{ Await, Future }
-import scala.io.Source
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.io.Source
 
 object AwaitFuture  {
 
@@ -10,7 +10,7 @@ object AwaitFuture  {
     Source.fromURL(url).getLines().mkString
   }
 
-  def fetchDataFrom(url : String, waitTime : Long = 0l) : Future[String] =  Future {
+  def fetchDataFrom(url : String, waitTime : Long = 0L) : Future[String] =  Future {
     Thread.sleep(waitTime)
     Source.fromURL(url).getLines().mkString
   }

--- a/scala-core-3/src/main/scala/com/baeldung/scala/typecasts/ErrorHandling.scala
+++ b/scala-core-3/src/main/scala/com/baeldung/scala/typecasts/ErrorHandling.scala
@@ -33,7 +33,7 @@ object ErrorHandling extends App {
     case Failure(e: UnknownHostException) =>
       println(s"Unknown host specified: ${e.getMessage}")
     case Failure(e: IOException) =>
-      println("Network failure: ${e.getMessage}")
+      println(s"Network failure: ${e.getMessage}")
     case Failure(t) =>
       t.printStackTrace()
   }

--- a/scala-core-4/src/main/scala/com/baeldung/scala/assertvsrequire/RequireUsage.scala
+++ b/scala-core-4/src/main/scala/com/baeldung/scala/assertvsrequire/RequireUsage.scala
@@ -12,7 +12,7 @@ object RequireUsage extends App {
     issueDrivingLicense("Jr. Darwin", 5) // prints "Failed in require precondition"
   } catch {
     case e: IllegalArgumentException =>
-      println("Failed in require precondition")
+      println("Failed in require precondition-"+e.getMessage)
   }
 
 }

--- a/scala-core-5/src/main/scala/com/baeldung/scala/datesandtimes/JavaUtilDate.scala
+++ b/scala-core-5/src/main/scala/com/baeldung/scala/datesandtimes/JavaUtilDate.scala
@@ -3,7 +3,6 @@ import java.text.SimpleDateFormat
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
-import scala.languageFeature.experimental.macros
 
 object JavaUtilDate extends App{
 
@@ -29,5 +28,5 @@ object JavaUtilDate extends App{
   val date1 = Await.result(r1, Duration.Inf)
   val date2 = Await.result(r2, Duration.Inf)
 
-  println(date1, date2) // Prints "Wed Jul 01 2020, Fri Aug 21 2020"
+  println(date1 +", "+ date2) // Prints "Wed Jul 01 2020, Fri Aug 21 2020"
 }

--- a/scala-core/src/main/scala/com/baeldung/scala/exceptionhandling/Examples.scala
+++ b/scala-core/src/main/scala/com/baeldung/scala/exceptionhandling/Examples.scala
@@ -1,6 +1,6 @@
 package com.baeldung.scala.exceptionhandling
 
-import scala.util.{Failure, Success, Try, control}
+import scala.util.Try
 import scala.util.control.Exception._
 
 object Examples {

--- a/scala-design-patterns/src/main/scala/com/baeldung/scala/cakepattern/CakePattern.scala
+++ b/scala-design-patterns/src/main/scala/com/baeldung/scala/cakepattern/CakePattern.scala
@@ -1,6 +1,6 @@
 package com.baeldung.scala.cakepattern
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object CakePattern {
 

--- a/scala-js/build.sbt
+++ b/scala-js/build.sbt
@@ -9,7 +9,7 @@ lazy val root = (project in file("."))
     jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv()
   )
 
-scalaVersion := "2.13.1"
+scalaVersion := "2.13.10"
 
 scalaJSUseMainModuleInitializer := true
 libraryDependencies += "org.scala-js" %%% "scalajs-dom" % "2.2.0"

--- a/scala-lagom/build.sbt
+++ b/scala-lagom/build.sbt
@@ -2,7 +2,7 @@ organization in ThisBuild := "com.baeldung"
 version in ThisBuild := "1.0-SNAPSHOT"
 
 // the Scala version that will be used for cross-compiled libraries
-scalaVersion in ThisBuild := "2.13.0"
+scalaVersion in ThisBuild := "2.13.10"
 
 val macwire = "com.softwaremill.macwire" %% "macros" % "2.3.3" % "provided"
 val scalaTest = "org.scalatest" %% "scalatest" % "3.1.1" % Test

--- a/scala-lang-2/src/main/scala/com/baeldung/scala/voidtypes/UnitReturnType.scala
+++ b/scala-lang-2/src/main/scala/com/baeldung/scala/voidtypes/UnitReturnType.scala
@@ -10,7 +10,7 @@ object UnitReturnType extends App{
   println("result of function returning Unit: %s".format(functionReturnUnit))
 
   def functionReturnImplicitUnit{
-    """
+    s"""
       do something, don't return anything
     """
   }

--- a/scala-libraries-2/src/main/scala/com/baeldung/cache/service/AsyncQueryMemoizeService.scala
+++ b/scala-libraries-2/src/main/scala/com/baeldung/cache/service/AsyncQueryMemoizeService.scala
@@ -4,7 +4,6 @@ import scalacache._
 import scalacache.guava._
 import com.google.common.cache.CacheBuilder
 import scalacache.modes.scalaFuture._
-import scalacache.serialization.binary._
 import scalacache.memoization._
 import scala.concurrent.ExecutionContext.Implicits.global
 

--- a/scala-libraries-2/src/main/scala/com/baeldung/cache/service/CatsService.scala
+++ b/scala-libraries-2/src/main/scala/com/baeldung/cache/service/CatsService.scala
@@ -5,7 +5,6 @@ import com.google.common.cache.CacheBuilder
 import scalacache._
 import scalacache.memoization._
 import scalacache.guava.GuavaCache
-import scala.concurrent.duration._
 
 object GuavaCacheCatsConfig {
   val underlyingGuavaCacheCats =

--- a/scala-libraries-2/src/main/scala/com/baeldung/cache/service/SyncQueryCustomMemoizeKeyService.scala
+++ b/scala-libraries-2/src/main/scala/com/baeldung/cache/service/SyncQueryCustomMemoizeKeyService.scala
@@ -1,12 +1,10 @@
 package com.baeldung.cache.service
 
+import com.google.common.cache.CacheBuilder
 import scalacache._
 import scalacache.guava._
-import com.google.common.cache.CacheBuilder
-import scalacache.memoization.MethodCallToStringConverter.onlyMethodParams
-import scalacache.modes.sync._
-import scalacache.serialization.binary._
 import scalacache.memoization._
+import scalacache.modes.sync._
 
 import scala.concurrent.duration._
 

--- a/scala-libraries-2/src/main/scala/com/baeldung/cache/service/SyncQueryMemoizeService.scala
+++ b/scala-libraries-2/src/main/scala/com/baeldung/cache/service/SyncQueryMemoizeService.scala
@@ -1,13 +1,12 @@
 package com.baeldung.cache.service
 
+import com.google.common.cache.CacheBuilder
 import scalacache._
 import scalacache.guava._
-import com.google.common.cache.CacheBuilder
-import scalacache.serialization.binary._
 import scalacache.memoization._
 
 import scala.concurrent.duration._
-import scala.util.{Failure, Try}
+import scala.util.Try
 
 object GuavaCacheMemoizationConfig {
   val memoizedUnderlyingGuavaCache =
@@ -18,8 +17,8 @@ object GuavaCacheMemoizationConfig {
 }
 
 class SyncQueryMemoizeService {
-  import scalacache.modes.sync._
   import GuavaCacheMemoizationConfig._
+  import scalacache.modes.sync._
 
   var queryCount = 0
 
@@ -44,8 +43,8 @@ class SyncQueryMemoizeService {
 }
 
 class TryMemoizeService {
-  import scalacache.modes.try_._
   import GuavaCacheMemoizationConfig._
+  import scalacache.modes.try_._
 
   var queryCount = 0
   var failQueryCount = 0

--- a/scala-libraries-2/src/test/scala/com/baeldung/akka/Tests.scala
+++ b/scala-libraries-2/src/test/scala/com/baeldung/akka/Tests.scala
@@ -72,7 +72,7 @@ class GreeterTest extends TestService {
   sender ! Greeter.GreetingRequest(greeting, probe.ref)
   probe.expectMessage(Greeter.GreetingResponse(greeting))
   // no other message should be received by the greeter actor
-  probe.expectNoMessage(50 millis)
+  probe.expectNoMessage(50.millis)
 }
 
 class TrafficLightTest extends TestService {
@@ -83,29 +83,29 @@ class TrafficLightTest extends TestService {
   // ensure that initial state is RED
   sender ! TrafficLight.SignalCommand.GetSignal(probe.ref)
   probe.expectMessage(TrafficLight.CurrentSignal(TrafficLight.Signal.RED))
-  probe.expectNoMessage(50 millis)
+  probe.expectNoMessage(50.millis)
 
 
   // now try to change signal
   sender ! TrafficLight.SignalCommand.ChangeSignal(probe.ref)
   probe.expectMessage(TrafficLight.CurrentSignal(TrafficLight.Signal.YELLOW))
   // ensure no other message is received
-  probe.expectNoMessage(50 millis)
+  probe.expectNoMessage(50.millis)
 
   // ensure that the state is preserved
   sender ! TrafficLight.SignalCommand.ChangeSignal(probe.ref)
   probe.expectMessage(TrafficLight.CurrentSignal(TrafficLight.Signal.GREEN))
-  probe.expectNoMessage(50 millis)
+  probe.expectNoMessage(50.millis)
   //ensure that the state is preserved
   sender ! TrafficLight.SignalCommand.ChangeSignal(probe.ref)
   probe.expectMessage(TrafficLight.CurrentSignal(TrafficLight.Signal.RED))
-  probe.expectNoMessage(50 millis)
+  probe.expectNoMessage(50.millis)
 }
 
 class TrafficLightTestFut extends TestService {
   import scala.concurrent.duration._
   val sender = testKit.spawn(TrafficLight(), "traffic")
-  val duration = 300 millis
+  val duration = 300.millis
   implicit val timeout = Timeout(duration)
 
   val signalFut =  sender.ask(replyTo =>TrafficLight.SignalCommand.GetSignal(replyTo))

--- a/scala-libraries-3/src/main/scala/com/baeldung/scala/pureconfig/Configs.scala
+++ b/scala-libraries-3/src/main/scala/com/baeldung/scala/pureconfig/Configs.scala
@@ -3,13 +3,11 @@ package com.baeldung.pureconfig
 import enumeratum._
 import pureconfig._
 import pureconfig.configurable._
-import pureconfig.generic.auto._
 import pureconfig.generic.semiauto._
 
-import java.time.{LocalDate, LocalDateTime}
+import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import scala.concurrent.duration.FiniteDuration
-import pureconfig.module.enumeratum._
 
 sealed trait Protocol
 object Protocol {
@@ -53,11 +51,6 @@ object Env extends Enum[Env] {
 final case class BaseAppConfig(appName: String, baseDate: LocalDate, env: Env)
 
 
-import pureconfig._
-import pureconfig.generic.auto._
-import pureconfig.module.enumeratum._
-import com.typesafe.config.ConfigFactory.parseString
-import enumeratum._
 import enumeratum.EnumEntry._
 
 sealed trait Greeting extends EnumEntry with Snakecase

--- a/scala-libraries-3/src/main/scala/com/baeldung/scala/spark/RDDToDataframe.scala
+++ b/scala-libraries-3/src/main/scala/com/baeldung/scala/spark/RDDToDataframe.scala
@@ -6,7 +6,7 @@ import org.apache.spark.rdd.RDD
 
 object RDDToDataframe extends App{
 
-  val spark: SparkSession = SparkSession.builder.master("local").getOrCreate
+  val spark: SparkSession = SparkSession.builder().master("local").getOrCreate
   val sc = spark.sparkContext
 
   val rdd = sc.parallelize(

--- a/scala-libraries-3/src/main/scala/com/baeldung/scala/spark/rdd/PrintRDD.scala
+++ b/scala-libraries-3/src/main/scala/com/baeldung/scala/spark/rdd/PrintRDD.scala
@@ -3,7 +3,7 @@ package com.baeldung.scala.spark.rdd
 import org.apache.spark.sql.SparkSession
 
 object PrintRDD extends App {
-  val spark: SparkSession = SparkSession.builder.master("local").getOrCreate
+  val spark: SparkSession = SparkSession.builder().master("local").getOrCreate
   import spark.implicits._
 
   val numbers = List(4, 6, 1, 7, 12, 2)

--- a/scala-libraries-3/src/main/scala/com/baeldung/scala/spark/rdd/RDDTutorial.scala
+++ b/scala-libraries-3/src/main/scala/com/baeldung/scala/spark/rdd/RDDTutorial.scala
@@ -5,7 +5,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 
 object RDDTutorial extends App {
-  val spark: SparkSession = SparkSession.builder.master("local").getOrCreate
+  val spark: SparkSession = SparkSession.builder().master("local").getOrCreate
   val sc: SparkContext = spark.sparkContext
 
   val animals = List("dog", "cat", "frog", "horse")
@@ -14,8 +14,8 @@ object RDDTutorial extends App {
   val countLengthRDD = animalsRDD.map(animal => (animal, animal.length))
   val noCRDD = animalsRDD.filter(_.startsWith("c"))
 
-  countLengthRDD.collect
-  noCRDD.collect
+  countLengthRDD.collect()
+  noCRDD.collect()
 
   val numbers = sc.parallelize(List(1, 2, 3, 4, 5))
   val numbersSum = numbers.reduce(_ + _)

--- a/scala-libraries-os/src/main/scala/com/baeldung/scala/os/ScalaSysApp.scala
+++ b/scala-libraries-os/src/main/scala/com/baeldung/scala/os/ScalaSysApp.scala
@@ -14,6 +14,6 @@ object ScalaSysApp extends App {
   val resultErr = "ls -l dir".!
 
   val source = Source.fromFile("./LICENSE")
-  val lines = source.getLines.size
+  val lines = source.getLines().size
   source.close()
 }

--- a/scala-libraries/src/main/scala/com/baeldung/scala/fs2/Fs2Examples.scala
+++ b/scala-libraries/src/main/scala/com/baeldung/scala/fs2/Fs2Examples.scala
@@ -1,14 +1,9 @@
 package com.baeldung.scala.fs2
 
-import java.io.{File, PrintWriter}
-import java.nio.file.Paths
-
 import cats.effect.{Async, Blocker, ContextShift, IO}
-
-import scala.util.Random
 import fs2._
 
-import scala.collection.mutable
+import java.nio.file.Paths
 
 object Fs2Examples {
 

--- a/scala-sbt/intro-to-sbt/build.sbt
+++ b/scala-sbt/intro-to-sbt/build.sbt
@@ -1,6 +1,6 @@
 import Dependencies._
 
-ThisBuild / scalaVersion := "2.13.8"
+ThisBuild / scalaVersion := "2.13.10"
 ThisBuild / version := "0.1.0-SNAPSHOT"
 
 lazy val printHello = taskKey[Unit]("prints hello")

--- a/scala-test-junit5/build.sbt
+++ b/scala-test-junit5/build.sbt
@@ -3,7 +3,7 @@ organization := "com.baeldung"
 
 version := "1.0-SNAPSHOT"
 
-scalaVersion := "2.13.6"
+scalaVersion := "2.13.10"
 
 resolvers += Resolver.jcenterRepo
 

--- a/scala-test/src/test/scala/com/baeldung/scala/scalatest/mockito/InventoryServiceTest.scala
+++ b/scala-test/src/test/scala/com/baeldung/scala/scalatest/mockito/InventoryServiceTest.scala
@@ -43,8 +43,10 @@ class InventoryServiceTest extends AnyWordSpec with MockitoSugar with ScalaFutur
       val service = new InventoryService(dao, mockProducer, mockLogger)
       when(dao.saveAsync(any[InventoryTransaction])).thenReturn(Future.successful(txn))
       doNothing().when(mockProducer).publish(txn)
-      service.saveAndPublish(txn)
-      verify(mockProducer, times(1)).publish(any[InventoryTransaction])
+      val result = service.saveAndPublish(txn)
+      whenReady(result){ _ =>
+        verify(mockProducer, times(1)).publish(any[InventoryTransaction])
+      }
     }
 
     "save and NOT publish to kafka for non chocolate inventory" in {

--- a/scalatra/build.sbt
+++ b/scalatra/build.sbt
@@ -1,6 +1,6 @@
 val ScalatraVersion = "2.8.2"
 
-ThisBuild / scalaVersion := "2.13.4"
+ThisBuild / scalaVersion := "2.13.10"
 ThisBuild / organization := "baeldung"
 
 lazy val hello = (project in file("."))

--- a/zio/src/main/scala/com/baeldung/scala/zio/resources/ResourceHandling.scala
+++ b/zio/src/main/scala/com/baeldung/scala/zio/resources/ResourceHandling.scala
@@ -18,7 +18,7 @@ object ResourceHandling extends ZIOAppDefault {
   val complexZIO = simpleZIO *> failingZIO *> ZIO.succeed(println("Final step in chain"))
   val complexZIOWithFinalizer = complexZIO.ensuring(finalizerBlock)
 
-  val finalizer2 = ZIO.suspend {
+  val finalizer2: RIO[String, Nothing] = ZIO.suspend {
     throw new Exception
   }
 


### PR DESCRIPTION
# Changes

- Upgraded all scala 2.13 versions to latest minor version (2.13.10)
- Upgraded scala 3 version to 3.2.0
- Fixed many of the warnings after 2.13 upgrade. However, there are many warnings still, but many are expected as we are showing different cases about them in the articles. 
- Moved scala-libraries-2 version to 2.13.10 (that was still in 2.12 due to conflict). Had to upgrade akka in this module to 2.6.19 to make it work as well.
- Removed unnecessary spark dep from one module

Note: There is one module with 2.12, since there are some articles related to those dropped features.