### PR TITLE
Upgraded Most Libraries to latest version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,27 +4,33 @@ ThisBuild / version := "1.0-SNAPSHOT"
 ThisBuild / organization := "com.baeldung"
 ThisBuild / organizationName := "core-scala"
 
-val scalaTest = "org.scalatest" %% "scalatest" % "3.1.2" % Test
 val junit = "com.novocode" % "junit-interface" % "0.11" % "test"
 val catsEffect = "org.typelevel" %% "cats-effect" % "2.1.4"
 val catsCore = "org.typelevel" %% "cats-effect" % "2.1.4"
+
+val scalaTestDeps = Seq(
+  "org.scalatest" %% "scalatest" % "3.2.15" % Test,
+  "org.scalatest" %% "scalatest-shouldmatchers" % "3.2.15" % Test,
+  "org.scalatest" %% "scalatest-wordspec" % "3.2.15" % Test,
+  "org.scalatest" %% "scalatest-flatspec" % "3.2.15" % Test,
+)
+
 
 lazy val scala_core = (project in file("scala-core"))
   .settings(
     name := "scala-core",
     libraryDependencies ++=
       Seq(
-        scalaTest,
         junit,
         catsCore,
         catsEffect
-      )
+      ) ++ scalaTestDeps
   )
 
 lazy val scala_core_2 = (project in file("scala-core-2"))
   .settings(
     name := "scala-core-2",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+    libraryDependencies ++= scalaTestDeps,
     libraryDependencies += "org.scalamock" %% "scalamock" % "4.4.0" % Test,
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
   )
@@ -32,7 +38,7 @@ lazy val scala_core_2 = (project in file("scala-core-2"))
 lazy val scala_core_3 = (project in file("scala-core-3"))
   .settings(
     name := "scala-core-3",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+    libraryDependencies ++= scalaTestDeps,
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test",
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaV,
     libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "2.0.0-M1"
@@ -41,7 +47,7 @@ lazy val scala_core_3 = (project in file("scala-core-3"))
 lazy val scala_core_4 = (project in file("scala-core-4"))
   .settings(
     name := "scala-core-4",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+    libraryDependencies ++= scalaTestDeps,
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test",
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaV,
     libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "2.0.0-M1"
@@ -50,7 +56,7 @@ lazy val scala_core_4 = (project in file("scala-core-4"))
 lazy val scala_core_5 = (project in file("scala-core-5"))
   .settings(
     name := "scala-core-5",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+    libraryDependencies ++= scalaTestDeps,
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test",
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaV,
     libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "2.0.0-M1",
@@ -62,7 +68,7 @@ lazy val scala_core_5 = (project in file("scala-core-5"))
 lazy val scala_core_6 = (project in file("scala-core-6"))
   .settings(
     name := "scala-core-6",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+    libraryDependencies ++= scalaTestDeps,
     libraryDependencies += "org.scalamock" %% "scalamock" % "4.4.0" % Test,
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
   )
@@ -70,7 +76,7 @@ lazy val scala_core_6 = (project in file("scala-core-6"))
 lazy val scala_core_7 = (project in file("scala-core-7"))
   .settings(
     name := "scala-core-7",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+    libraryDependencies ++= scalaTestDeps,
     libraryDependencies += "org.scalamock" %% "scalamock" % "4.4.0" % Test,
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test",
     libraryDependencies += "com.github.scopt" %% "scopt" % "4.0.1",
@@ -84,7 +90,7 @@ lazy val scala_core_8 = (project in file("scala-core-8"))
   .settings(
     name := "scala-core-8",
     libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-    libraryDependencies += scalaTest,
+    libraryDependencies ++= scalaTestDeps,
     libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value % "test"
     // scalacOptions += "-Ymacro-debug-lite"
   )
@@ -92,7 +98,7 @@ lazy val scala_core_8 = (project in file("scala-core-8"))
 lazy val scala_core_io = (project in file("scala-core-io"))
   .settings(
     name := "scala-core-io",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+    libraryDependencies ++= scalaTestDeps,
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test",
     libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaV
   )
@@ -101,44 +107,42 @@ lazy val scala_core_oop = (project in file("scala-core-oop"))
   .settings(
     name := "scala-core-oop",
     libraryDependencies ++=
-      Seq(catsCore, scalaTest, junit)
+      Seq(catsCore, junit) ++ scalaTestDeps
   )
 
 lazy val scala_core_fp = (project in file("scala-core-fp"))
   .settings(
     name := "scala-core-fp",
     libraryDependencies ++=
-      Seq(catsCore, scalaTest, junit)
+      Seq(catsCore, junit) ++ scalaTestDeps
   )
 
 lazy val scala_lang = (project in file("scala-lang"))
   .settings(
     name := "scala-lang",
     libraryDependencies ++=
-      Seq(scalaTest, junit)
+      Seq(junit) ++ scalaTestDeps
   )
 
 lazy val scala_lang_2 = (project in file("scala-lang-2"))
   .settings(
     name := "scala-lang",
     libraryDependencies ++=
-      Seq(scalaTest, junit)
+      Seq(junit) ++ scalaTestDeps
   )
 
 lazy val scala_core_collections = (project in file("scala-core-collections"))
   .settings(
     name := "scala-core-collections",
     libraryDependencies ++= Seq(
-      scalaTest,
       "org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.4"
-    )
+    ) ++ scalaTestDeps,
   )
 
 lazy val scala_core_collections_2 = (project in file("scala-core-collections-2"))
   .settings(
     name := "scala-core-collections-2",
-    libraryDependencies +=
-      "org.scalatest" %% "scalatest" % "3.2.14" % Test
+    libraryDependencies ++= scalaTestDeps,
   )
 
 lazy val scala_test = (project in file("scala-test"))
@@ -147,10 +151,9 @@ lazy val scala_test = (project in file("scala-test"))
     libraryDependencies ++=
       Seq(
         "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test,
-        "org.scalatest" %% "scalatest" % "3.2.11" % Test,
         junit,
         "org.scalamock" %% "scalamock" % "4.4.0" % Test
-      )
+      ) ++ scalaTestDeps
   )
 
 lazy val scala_akka_dependencies: Seq[ModuleID] = Seq(
@@ -161,11 +164,10 @@ lazy val scala_akka_dependencies: Seq[ModuleID] = Seq(
   "com.typesafe.akka" %% "akka-stream" % "2.6.19",
   "org.mongodb.scala" %% "mongo-scala-driver" % "2.9.0",
   "com.lightbend.akka" %% "akka-stream-alpakka-file" % "2.0.2",
-  "org.scalatest" %% "scalatest" % "3.1.2" % Test,
   "com.novocode" % "junit-interface" % "0.11" % "test",
   "de.flapdoodle.embed" % "de.flapdoodle.embed.mongo" % "2.2.0" % Test,
   "com.typesafe.akka" %% "akka-http" % "10.2.7"
-)
+) ++ scalaTestDeps
 lazy val scala_test_junit4 = (project in file("scala-test-junit4"))
   .settings(
     name := "scala-test-junit4",
@@ -193,8 +195,7 @@ lazy val scala_akka_2 = (project in file("scala-akka-2"))
       "com.typesafe.akka" %% "akka-http-spray-json" % "10.2.10",
       "com.lightbend.akka" %% "akka-stream-alpakka-sse" % "4.0.0",
       "com.typesafe.akka" %% "akka-actor-testkit-typed" % "2.6.19" % Test,
-      "org.scalatest" %% "scalatest" % "3.0.8" % Test
-    )
+    ) ++ scalaTestDeps
   )
 val monocleVersion = "2.0.4"
 val slickVersion = "3.3.2"
@@ -207,7 +208,7 @@ val reactiveMongo = "1.0.3"
 lazy val scala_libraries = (project in file("scala-libraries"))
   .settings(
     name := "scala-libraries",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+    libraryDependencies ++= scalaTestDeps,
     libraryDependencies ++= Seq(
       "com.github.julien-truffaut" %% "monocle-core" % monocleVersion,
       "com.github.julien-truffaut" %% "monocle-macro" % monocleVersion,
@@ -239,7 +240,7 @@ lazy val scala_libraries_2 = (project in file("scala-libraries-2"))
   .settings(
     scalaVersion := "2.12.15",
     name := "scala-libraries",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+    libraryDependencies ++= scalaTestDeps,
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,
@@ -268,10 +269,9 @@ lazy val scala_libraries_2 = (project in file("scala-libraries-2"))
     ),
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-actor-testkit-typed" % "2.6.16" % Test,
-      "org.scalatest" %% "scalatest" % "3.1.4" % Test,
       "org.scalacheck" %% "scalacheck" % "1.14.1" % Test,
       "com.lihaoyi" %% "requests" % "0.6.9"
-    ),
+    ) ++ scalaTestDeps,
     libraryDependencies ++= Seq(
       "com.sksamuel.elastic4s" %% "elastic4s-client-esjava" % elastic4sVersion,
       "com.sksamuel.elastic4s" %% "elastic4s-core" % elastic4sVersion,
@@ -284,7 +284,7 @@ val http4sVersion = "0.23.10"
 lazy val scala_libraries_3 = (project in file("scala-libraries-3"))
   .settings(
     name := "scala-libraries",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+    libraryDependencies ++= scalaTestDeps,
     libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-core" % sparkVersion,
       "org.apache.spark" %% "spark-sql" % sparkVersion
@@ -311,7 +311,7 @@ lazy val scala_libraries_3 = (project in file("scala-libraries-3"))
 lazy val scala_libraries_os = (project in file("scala-libraries-os"))
   .settings(
     name := "scala-libraries",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+    libraryDependencies ++= scalaTestDeps,
     libraryDependencies ++= Seq(
       "org.apache.logging.log4j" %% "log4j-api-scala" % "12.0",
       "org.apache.logging.log4j" % "log4j-core" % "2.13.0" % Runtime
@@ -324,7 +324,7 @@ lazy val scala_libraries_4 = (project in file("scala-libraries-4"))
     name := "scala-libraries-4",
     libraryDependencies += "com.lihaoyi" %% "utest" % "0.8.1" % "test",
     testFrameworks += new TestFramework("utest.runner.Framework"),
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+    libraryDependencies ++= scalaTestDeps,
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-async" % "1.0.1",
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
@@ -340,21 +340,25 @@ lazy val scala_libraries_4 = (project in file("scala-libraries-4"))
 lazy val scala_strings = (project in file("scala-strings"))
   .settings(
     name := "scala-strings",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+    libraryDependencies ++= scalaTestDeps,
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test"
   )
 
 lazy val scala_design_patterns = (project in file("scala-design-patterns"))
   .settings(
     name := "scala-design-patterns",
-    libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % Test,
+    libraryDependencies ++= scalaTestDeps,
     libraryDependencies += "org.scalamock" %% "scalamock" % "4.4.0" % Test,
     libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % Test
   )
 
-lazy val scala3_lang = project in file("scala3-lang")
+lazy val scala3_lang = (project in file("scala3-lang")).settings(
+  libraryDependencies ++= scalaTestDeps
+)
 
-lazy val scala3_lang_2 = project in file("scala3-lang-2")
+lazy val scala3_lang_2 = (project in file("scala3-lang-2")).settings(
+  libraryDependencies ++= scalaTestDeps
+  )
 
 lazy val cats_effects = (project in file("cats-effects"))
   .settings(
@@ -411,7 +415,5 @@ lazy val scala212 = (project in file("scala212"))
   .settings(
     scalaVersion := "2.12.17",
     name := "scala212",
-    libraryDependencies ++= Seq(
-      scalaTest
-    )
+    libraryDependencies ++= scalaTestDeps
   )

--- a/build.sbt
+++ b/build.sbt
@@ -326,7 +326,8 @@ lazy val scala_libraries_4 = (project in file("scala-libraries-4"))
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.2" % Test,
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-async" % "1.0.1",
-      "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
+      "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
+      "org.tpolecat" %% "skunk-core" % "0.3.2"
     ),
      libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-core" % sparkVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -321,6 +321,10 @@ lazy val scala_libraries_4 = (project in file("scala-libraries-4"))
       "org.scala-lang.modules" %% "scala-async" % "1.0.1",
       "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided
     ),
+     libraryDependencies ++= Seq(
+      "org.apache.spark" %% "spark-core" % sparkVersion,
+      "org.apache.spark" %% "spark-sql" % sparkVersion
+    ),
     scalacOptions += "-Xasync"
   )
 

--- a/cats-effects/src/main/scala/com/baeldung/scala/catseffects/NotParallelApp.scala
+++ b/cats-effects/src/main/scala/com/baeldung/scala/catseffects/NotParallelApp.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.catseffects
 
 import cats.effect.{ExitCode, IO, IOApp}
-import com.baeldung.scala.catseffects.Utils.ShowThread
 import cats.implicits._
+import com.baeldung.scala.catseffects.Utils.ShowThread
 
 object NotParallelApp extends IOApp {
   val tasks: List[IO[Int]] = (1 to 10).map(IO.pure).map(_.showThread).toList

--- a/cats-effects/src/main/scala/com/baeldung/scala/catseffects/ParallelApp.scala
+++ b/cats-effects/src/main/scala/com/baeldung/scala/catseffects/ParallelApp.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.catseffects
 
 import cats.effect.{ExitCode, IO, IOApp}
-import com.baeldung.scala.catseffects.Utils.ShowThread
 import cats.implicits._
+import com.baeldung.scala.catseffects.Utils.ShowThread
 
 object ParallelApp extends IOApp {
   val tasks: List[IO[Int]] = (1 to 10).map(IO.pure).map(_.showThread).toList

--- a/cats-effects/src/main/scala/com/baeldung/scala/differences/Differences.scala
+++ b/cats-effects/src/main/scala/com/baeldung/scala/differences/Differences.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.differences
-import cats.effect.IO
-import scala.concurrent.duration._
+import cats.effect.{IO, IOApp}
 import cats.effect.kernel.Deferred
-import cats.effect.IOApp
+
+import scala.concurrent.duration._
 
 object Differences extends IOApp.Simple {
 

--- a/cats-effects/src/main/scala/com/baeldung/scala/differences/FlatEvalDiff.scala
+++ b/cats-effects/src/main/scala/com/baeldung/scala/differences/FlatEvalDiff.scala
@@ -1,9 +1,6 @@
 package com.baeldung.scala.differences
 
-import cats.effect.IOApp
-import cats.effect.IO
-import cats.effect.Resource
-import cats.effect.std.Random
+import cats.effect.{IO, IOApp, Resource}
 
 object FlatEvalDiff extends IOApp.Simple {
 

--- a/cats-effects/src/main/scala/com/baeldung/scala/fibers/Fibers.scala
+++ b/cats-effects/src/main/scala/com/baeldung/scala/fibers/Fibers.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.fibers
 
-import cats.effect.{FiberIO, IO, IOApp, OutcomeIO}
-import IOExtensions._
 import cats.effect.kernel.Outcome
+import cats.effect.{FiberIO, IO, IOApp, OutcomeIO}
+import com.baeldung.scala.fibers.IOExtensions._
 
 import scala.concurrent.duration._
 import scala.util.Random

--- a/cats-effects/src/main/scala/com/baeldung/scala/resources/ResourceHandling.scala
+++ b/cats-effects/src/main/scala/com/baeldung/scala/resources/ResourceHandling.scala
@@ -1,12 +1,9 @@
 package com.baeldung.scala.resources
 
-import cats.effect.IO
-import java.io.File
-import scala.io.Source
-import cats.effect.IOApp
-import scala.io.BufferedSource
+import cats.effect.{IO, IOApp, Resource}
+
 import java.io.FileWriter
-import cats.effect.Resource
+import scala.io.Source
 
 object ResourceHandling extends IOApp.Simple {
 

--- a/doobie/src/main/scala/com/baeldung/scala/doobie/DoobieFragments.scala
+++ b/doobie/src/main/scala/com/baeldung/scala/doobie/DoobieFragments.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.doobie
 
 import cats.effect.{IO, IOApp}
-import doobie.{Fragment, Transactor}
 import doobie.implicits._
+import doobie.{Fragment, Transactor}
 
 object DoobieFragments extends IOApp.Simple {
 

--- a/doobie/src/main/scala/com/baeldung/scala/doobie/DoobieQuickStart.scala
+++ b/doobie/src/main/scala/com/baeldung/scala/doobie/DoobieQuickStart.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.doobie
 
 import cats.effect.{IO, IOApp}
-import doobie.{ConnectionIO, Transactor}
 import doobie.implicits._
+import doobie.{ConnectionIO, Transactor}
 
 // Equivalent to world db city table
 case class City(id: Long, name: String, countryCode: String, district: String, population: Int)

--- a/play-scala/dependency-injection/test/macwire/service/ServiceWithRemoteCallTest.scala
+++ b/play-scala/dependency-injection/test/macwire/service/ServiceWithRemoteCallTest.scala
@@ -1,9 +1,9 @@
 package macwire.service
 
 import macwire.components.{ApiComponents, MockApiComponents, ServiceComponents}
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class ServiceWithRemoteCallTest extends WordSpec {
+class ServiceWithRemoteCallTest extends AnyWordSpec {
 
   "ServiceWithRemoteCall call" should {
 

--- a/scala-akka-2/src/main/scala/com/baeldung/scala/akka/http/MovieServer.scala
+++ b/scala-akka-2/src/main/scala/com/baeldung/scala/akka/http/MovieServer.scala
@@ -1,15 +1,15 @@
 package com.baeldung.scala.akka.http
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model._
-import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.Http
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala._
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
-import spray.json.DefaultJsonProtocol._
-import scala.util._
+import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.server.Directives._
+import spray.json.DefaultJsonProtocol._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util._
 
 object MovieServer extends App {
 

--- a/scala-akka-2/src/main/scala/com/baeldung/scala/akka/http/MovieService.scala
+++ b/scala-akka-2/src/main/scala/com/baeldung/scala/akka/http/MovieService.scala
@@ -1,7 +1,6 @@
 package com.baeldung.scala.akka.http
-import scala.concurrent.Future
-import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 case class Movie(id: Int, name: String, length: Int)
 

--- a/scala-akka-2/src/main/scala/com/baeldung/scala/akka_2/grpc/MessageExchangeServiceImpl.scala
+++ b/scala-akka-2/src/main/scala/com/baeldung/scala/akka_2/grpc/MessageExchangeServiceImpl.scala
@@ -1,6 +1,6 @@
 package com.baeldung.scala.akka_2.grpc
-import akka.stream.Materializer
 import akka.NotUsed
+import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
 import com.google.protobuf.timestamp.Timestamp
 

--- a/scala-akka-2/src/test/scala/com/baeldung/scala/akka_2/alpakka_sse/WikimediaSSEConsumerTest.scala
+++ b/scala-akka-2/src/test/scala/com/baeldung/scala/akka_2/alpakka_sse/WikimediaSSEConsumerTest.scala
@@ -2,7 +2,8 @@ package com.baeldung.scala.akka_2.alpakka_sse
 
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
-import org.scalatest.{AsyncWordSpecLike, BeforeAndAfterAll}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AsyncWordSpecLike
 
 class WikimediaSSEConsumerTest
   extends TestKit(ActorSystem("wikimediaSSESpec"))

--- a/scala-akka-2/src/test/scala/com/baeldung/scala/akka_2/grpc/MessageExchangeServiceTest.scala
+++ b/scala-akka-2/src/test/scala/com/baeldung/scala/akka_2/grpc/MessageExchangeServiceTest.scala
@@ -1,12 +1,10 @@
 package com.baeldung.scala.akka_2.grpc
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.testkit.TestKit
-import org.scalatest.{AsyncWordSpecLike, BeforeAndAfterAll}
-
-import scala.concurrent.Future
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.wordspec.AsyncWordSpecLike
 
 class MessageExchangeServiceTest
   extends TestKit(ActorSystem("Akka-gRPC"))

--- a/scala-akka/src/main/scala/com/baeldung/scala/akka/actordiscovery/MathActorDiscovery.scala
+++ b/scala-akka/src/main/scala/com/baeldung/scala/akka/actordiscovery/MathActorDiscovery.scala
@@ -4,6 +4,7 @@ import akka.actor.typed.receptionist.{Receptionist, ServiceKey}
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ActorRef, ActorSystem, Behavior}
 import akka.util.Timeout
+
 import java.util.concurrent.TimeUnit
 import scala.util.Success
 

--- a/scala-akka/src/main/scala/com/baeldung/scala/akka/alpakka/AlpakkaMongoIntegration.scala
+++ b/scala-akka/src/main/scala/com/baeldung/scala/akka/alpakka/AlpakkaMongoIntegration.scala
@@ -1,7 +1,5 @@
 package com.baeldung.scala.akka.alpakka
 
-import java.nio.file.FileSystems
-
 import akka.NotUsed
 import akka.stream.alpakka.mongodb.scaladsl.MongoSink
 import akka.stream.scaladsl.Source

--- a/scala-akka/src/main/scala/com/baeldung/scala/akka/mailbox/Mailboxes.scala
+++ b/scala-akka/src/main/scala/com/baeldung/scala/akka/mailbox/Mailboxes.scala
@@ -2,8 +2,8 @@ package com.baeldung.scala.akka.mailbox
 
 import akka.actor.DeadLetter
 import akka.actor.typed.eventstream.EventStream
-import akka.actor.typed.{ActorRef, ActorSystem, Behavior, MailboxSelector}
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorRef, ActorSystem, Behavior, MailboxSelector}
 
 object Mailboxes {
 

--- a/scala-akka/src/main/scala/com/baeldung/scala/akka/requestresponse/Base64Application.scala
+++ b/scala-akka/src/main/scala/com/baeldung/scala/akka/requestresponse/Base64Application.scala
@@ -1,13 +1,12 @@
 package com.baeldung.scala.akka.requestresponse
 
-import java.nio.charset.StandardCharsets
-import java.util.Base64
-
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ActorRef, Behavior}
 import akka.util.Timeout
-import com.baeldung.scala.akka.requestresponse.Base64Application.Base64Encoder.{ToEncode, Encoded, Request}
+import com.baeldung.scala.akka.requestresponse.Base64Application.Base64Encoder.{Encoded, ToEncode}
 
+import java.nio.charset.StandardCharsets
+import java.util.Base64
 import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Success}
 

--- a/scala-akka/src/main/scala/com/baeldung/scala/akka/scheduler/TimerActor.scala
+++ b/scala-akka/src/main/scala/com/baeldung/scala/akka/scheduler/TimerActor.scala
@@ -2,6 +2,7 @@ package com.baeldung.scala.akka.scheduler
 
 import akka.actor.{Actor, ActorRef, Timers}
 import com.baeldung.scala.akka.scheduler.TimerActor._
+
 import scala.concurrent.duration._
 
 object TimerActor {

--- a/scala-akka/src/main/scala/com/baeldung/scala/akka/stopping/MessageProcessorActor.scala
+++ b/scala-akka/src/main/scala/com/baeldung/scala/akka/stopping/MessageProcessorActor.scala
@@ -1,10 +1,6 @@
 package com.baeldung.scala.akka.stopping
 
 import akka.actor.Actor
-import akka.actor.ActorSystem
-import akka.actor.Props
-import akka.actor.PoisonPill
-import akka.actor.DeadLetter
 
 object MessageProcessorActor {
   trait Message

--- a/scala-akka/src/main/scala/com/baeldung/scala/akka/supervision/SupervisionApplication.scala
+++ b/scala-akka/src/main/scala/com/baeldung/scala/akka/supervision/SupervisionApplication.scala
@@ -1,16 +1,15 @@
 package com.baeldung.scala.akka.supervision
 
-import java.io.IOException
-import java.net.URL
-
 import akka.actor.typed._
 import akka.actor.typed.scaladsl.{ActorContext, Behaviors}
 import akka.util.Timeout
 import com.baeldung.scala.akka.supervision.SupervisionApplication.Filesystem.{FsFind, FsFound}
 import com.baeldung.scala.akka.supervision.SupervisionApplication.WebServer.Request
 
+import java.io.IOException
+import java.net.URL
 import scala.concurrent.duration.DurationInt
-import scala.util.{Failure, Random, Success, Try}
+import scala.util.{Failure, Success, Try}
 
 object SupervisionApplication {
 

--- a/scala-akka/src/main/scala/com/baeldung/scala/akka/tell/LoggingApplication.scala
+++ b/scala-akka/src/main/scala/com/baeldung/scala/akka/tell/LoggingApplication.scala
@@ -1,7 +1,7 @@
 package com.baeldung.scala.akka.tell
 
-import akka.actor.typed.{ActorRef, Behavior}
 import akka.actor.typed.scaladsl.Behaviors
+import akka.actor.typed.{ActorRef, Behavior}
 
 object LoggingApplication {
   object LogKeeperActor {

--- a/scala-akka/src/main/scala/com/baeldung/scala/akka/typed/PortfolioApplication.scala
+++ b/scala-akka/src/main/scala/com/baeldung/scala/akka/typed/PortfolioApplication.scala
@@ -1,13 +1,12 @@
 package com.baeldung.scala.akka.typed
 
-import java.util.UUID
-
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ActorRef, ActorSystem, Behavior}
 import akka.util.Timeout
 import com.baeldung.scala.akka.typed.PortfolioApplication.Bank.{CreatePortfolio, PortfolioCreated}
 import com.baeldung.scala.akka.typed.PortfolioApplication.PortfolioActor.{Buy, PortfolioCommand}
 
+import java.util.UUID
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 

--- a/scala-akka/src/test/scala/com/baeldung/scala/akka/alpakka/AlpakkaIntegrationTest.scala
+++ b/scala-akka/src/test/scala/com/baeldung/scala/akka/alpakka/AlpakkaIntegrationTest.scala
@@ -1,7 +1,5 @@
 package com.baeldung.scala.akka.alpakka
 
-import java.nio.file.{FileSystems, Path, Paths}
-
 import akka.stream.alpakka.file.scaladsl.FileTailSource
 import akka.stream.alpakka.mongodb.scaladsl.MongoSource
 import akka.stream.scaladsl.{Sink, Source}
@@ -10,14 +8,17 @@ import de.flapdoodle.embed.mongo.MongodStarter
 import de.flapdoodle.embed.mongo.config.{MongodConfigBuilder, Net}
 import de.flapdoodle.embed.mongo.distribution.Version
 import de.flapdoodle.embed.process.runtime.Network
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
+import java.nio.file.{FileSystems, Path, Paths}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 class AlpakkaIntegrationTest
-  extends WordSpec
+  extends AnyWordSpec
     with Matchers
     with ScalaFutures
     with BeforeAndAfterAll {

--- a/scala-akka/src/test/scala/com/baeldung/scala/akka/requestresponse/Base64ApplicationUnitTest.scala
+++ b/scala-akka/src/test/scala/com/baeldung/scala/akka/requestresponse/Base64ApplicationUnitTest.scala
@@ -4,13 +4,14 @@ import akka.actor.testkit.typed.CapturedLogEvent
 import akka.actor.testkit.typed.Effect.MessageAdapter
 import akka.actor.testkit.typed.scaladsl.{ActorTestKit, BehaviorTestKit, TestInbox}
 import com.baeldung.scala.akka.requestresponse.Base64Application.APIGateway.{GentlyEncoded, PleaseEncode}
-import com.baeldung.scala.akka.requestresponse.Base64Application.Base64Encoder.{ToEncode, Encoded}
+import com.baeldung.scala.akka.requestresponse.Base64Application.Base64Encoder.{Encoded, ToEncode}
 import com.baeldung.scala.akka.requestresponse.Base64Application.EncoderClient.{KeepASecret, WrappedEncoderResponse}
 import com.baeldung.scala.akka.requestresponse.Base64Application.{APIGateway, Base64Encoder, EncoderClient, NaiveEncoderClient}
-import org.scalatest.{BeforeAndAfterAll, FlatSpec}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
 import org.slf4j.event.Level
 
-class Base64ApplicationUnitTest extends FlatSpec with BeforeAndAfterAll {
+class Base64ApplicationUnitTest extends AnyFlatSpec with BeforeAndAfterAll {
 
   val testKit: ActorTestKit = ActorTestKit()
 

--- a/scala-akka/src/test/scala/com/baeldung/scala/akka/scheduler/SchedulerUnitTest.scala
+++ b/scala-akka/src/test/scala/com/baeldung/scala/akka/scheduler/SchedulerUnitTest.scala
@@ -2,17 +2,19 @@ package com.baeldung.scala.akka.scheduler
 
 import akka.actor.{ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestKit}
-import org.scalatest.{Matchers, WordSpecLike}
-import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
 import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.{AnyWordSpec, AnyWordSpecLike}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
 
 @Ignore
 // fixing in JAVA-4839
 class SchedulerUnitTest
     extends TestKit(ActorSystem("test-system"))
     with ImplicitSender
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers {
 
   "Akka scheduler" must {

--- a/scala-akka/src/test/scala/com/baeldung/scala/akka/scheduler/TimerUnitTest.scala
+++ b/scala-akka/src/test/scala/com/baeldung/scala/akka/scheduler/TimerUnitTest.scala
@@ -2,7 +2,9 @@ package com.baeldung.scala.akka.scheduler
 
 import akka.actor.{ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestKit}
-import org.scalatest.{Matchers, WordSpecLike, Ignore}
+import org.scalatest.Ignore
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.concurrent.duration._
 
@@ -10,7 +12,7 @@ import scala.concurrent.duration._
 class TimerUnitTest
     extends TestKit(ActorSystem("test-system"))
     with ImplicitSender
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers {
 
   "Timer Actor" must {

--- a/scala-akka/src/test/scala/com/baeldung/scala/akka/stopping/GracefulStopActorTest.scala
+++ b/scala-akka/src/test/scala/com/baeldung/scala/akka/stopping/GracefulStopActorTest.scala
@@ -1,32 +1,25 @@
 package com.baeldung.scala.akka.stopping
 
-import akka.testkit.TestKit
-import akka.actor.ActorSystem
-import org.scalatest.WordSpec
-import org.scalatest.Matchers
-import akka.testkit.ImplicitSender
-import org.scalatest.WordSpecLike
-import akka.actor.Props
-import MessageProcessorActor._
-import akka.actor.PoisonPill
-import akka.testkit.TestActorRef
+import akka.actor.{ActorSystem, PoisonPill, Props}
+import akka.pattern.{AskTimeoutException, gracefulStop}
 import akka.testkit
-import akka.actor.DeadLetter
-import scala.concurrent.duration._
-import akka.pattern.gracefulStop
+import akka.testkit.{ImplicitSender, TestKit}
+import com.baeldung.scala.akka.stopping.MessageProcessorActor._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
 import scala.concurrent.Await
-import akka.pattern.AskTimeoutException
+import scala.concurrent.duration._
 
 class GracefulStopActorTest
   extends TestKit(ActorSystem("test_system"))
-  with WordSpecLike
+  with AnyWordSpecLike
   with Matchers
   with ImplicitSender {
 
   "Graceful shutdown" should {
 
     "stop the actor successfully" in {
-      import scala.concurrent.ExecutionContext.Implicits.global
       val actor = system.actorOf(Props(classOf[MessageProcessorActor]), "GracefulActor")
       val probe = testkit.TestProbe()
       probe.watch(actor)

--- a/scala-akka/src/test/scala/com/baeldung/scala/akka/stopping/PoisonPillActorTest.scala
+++ b/scala-akka/src/test/scala/com/baeldung/scala/akka/stopping/PoisonPillActorTest.scala
@@ -1,22 +1,15 @@
 package com.baeldung.scala.akka.stopping
 
-import akka.testkit.TestKit
-import akka.actor.ActorSystem
-import org.scalatest.WordSpec
-import org.scalatest.Matchers
-import akka.testkit.ImplicitSender
-import org.scalatest.WordSpecLike
-import akka.actor.Props
-import MessageProcessorActor._
-import akka.actor.PoisonPill
-import akka.testkit.TestActorRef
+import akka.actor.{ActorSystem, PoisonPill, Props}
 import akka.testkit
-import akka.actor.DeadLetter
-import scala.concurrent.duration._
+import akka.testkit.{ImplicitSender, TestKit}
+import com.baeldung.scala.akka.stopping.MessageProcessorActor._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 class PoisonPillActorTest
   extends TestKit(ActorSystem("test_system"))
-  with WordSpecLike
+  with AnyWordSpecLike
   with Matchers
   with ImplicitSender {
 

--- a/scala-akka/src/test/scala/com/baeldung/scala/akka/stopping/StopActorTest.scala
+++ b/scala-akka/src/test/scala/com/baeldung/scala/akka/stopping/StopActorTest.scala
@@ -1,31 +1,23 @@
 package com.baeldung.scala.akka.stopping
 
-import akka.testkit.TestKit
-import akka.actor.ActorSystem
-import org.scalatest.WordSpec
-import org.scalatest.Matchers
-import akka.testkit.ImplicitSender
-import org.scalatest.WordSpecLike
-import org.scalatest.Ignore
-import akka.actor.Props
-import MessageProcessorActor._
-import akka.actor.PoisonPill
-import akka.testkit.TestActorRef
+import akka.actor.{ActorSystem, Props}
 import akka.testkit
-import akka.actor.DeadLetter
-import scala.concurrent.duration._
+import akka.testkit.{ImplicitSender, TestKit}
+import com.baeldung.scala.akka.stopping.MessageProcessorActor._
+import org.scalatest.Ignore
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 @Ignore // fixing in JAVA-9841
 class StoppingActorTest
   extends TestKit(ActorSystem("test_system"))
-  with WordSpecLike
+  with AnyWordSpecLike
   with Matchers
   with ImplicitSender {
 
   "Stop method" should {
 
     "stop the actor using stop() method" in {
-      import scala.concurrent.ExecutionContext.Implicits.global
       val actor = system.actorOf(Props(classOf[MessageProcessorActor]), "StopActor")
       val probe = testkit.TestProbe()
       probe.watch(actor)

--- a/scala-akka/src/test/scala/com/baeldung/scala/akka/supervision/SupervisionApplicationUnitTest.scala
+++ b/scala-akka/src/test/scala/com/baeldung/scala/akka/supervision/SupervisionApplicationUnitTest.scala
@@ -4,13 +4,14 @@ import akka.actor.testkit.typed.scaladsl.{ActorTestKit, LoggingTestKit}
 import akka.actor.typed.ActorSystem
 import com.baeldung.scala.akka.supervision.SupervisionApplication.Cache.{Find, Hit}
 import com.baeldung.scala.akka.supervision.SupervisionApplication.Main.{Created, Start}
-import com.baeldung.scala.akka.supervision.SupervisionApplication.{Cache, File, Filesystem, WebServer}
 import com.baeldung.scala.akka.supervision.SupervisionApplication.WebServer.{BadRequest, Get, Ok, Response}
-import org.scalatest.{BeforeAndAfterAll, FlatSpec}
+import com.baeldung.scala.akka.supervision.SupervisionApplication.{Cache, Filesystem, WebServer}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
 
 import scala.concurrent.duration.DurationInt
 
-class SupervisionApplicationUnitTest extends FlatSpec with BeforeAndAfterAll {
+class SupervisionApplicationUnitTest extends AnyFlatSpec with BeforeAndAfterAll {
 
   val testKit: ActorTestKit = ActorTestKit()
   implicit val actorSystem: ActorSystem[_] = testKit.internalSystem

--- a/scala-akka/src/test/scala/com/baeldung/scala/akka/tell/LoggingApplicationUnitTest.scala
+++ b/scala-akka/src/test/scala/com/baeldung/scala/akka/tell/LoggingApplicationUnitTest.scala
@@ -4,10 +4,10 @@ import akka.actor.testkit.typed.CapturedLogEvent
 import akka.actor.testkit.typed.scaladsl.{BehaviorTestKit, TestInbox}
 import com.baeldung.scala.akka.tell.LoggingApplication.MicroserviceActor.DoSomeStuff
 import com.baeldung.scala.akka.tell.LoggingApplication.{LogKeeperActor, MicroserviceActor}
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 import org.slf4j.event.Level
 
-class LoggingApplicationUnitTest extends FlatSpec {
+class LoggingApplicationUnitTest extends AnyFlatSpec {
 
   "A LogKeeperActor" should "log received messages using the trace level" in {
     val logger = BehaviorTestKit(LogKeeperActor())

--- a/scala-akka/src/test/scala/com/baeldung/scala/akka/typed/PortfolioApplicationUnitTest.scala
+++ b/scala-akka/src/test/scala/com/baeldung/scala/akka/typed/PortfolioApplicationUnitTest.scala
@@ -5,10 +5,10 @@ import akka.actor.testkit.typed.scaladsl.{BehaviorTestKit, TestInbox}
 import com.baeldung.scala.akka.typed.PortfolioApplication.Bank.{CreatePortfolio, PortfolioCreated}
 import com.baeldung.scala.akka.typed.PortfolioApplication.BankMain.Start
 import com.baeldung.scala.akka.typed.PortfolioApplication.PortfolioActor.{Buy, PortfolioCommand}
-import com.baeldung.scala.akka.typed.PortfolioApplication.{Bank, BankClientUsingTheTellPattern, BankMain, Portfolio, PortfolioActor, Stock}
-import org.scalatest.FlatSpec
+import com.baeldung.scala.akka.typed.PortfolioApplication._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class PortfolioApplicationUnitTest extends FlatSpec {
+class PortfolioApplicationUnitTest extends AnyFlatSpec {
 
   "A Stock" should "let you add some quantity to actual" in {
     val appleStock = Stock("AAPL", 1000L)

--- a/scala-core-2/src/main/scala/com/baeldung/scala/concurrency/FutureAndPromise.scala
+++ b/scala-core-2/src/main/scala/com/baeldung/scala/concurrency/FutureAndPromise.scala
@@ -3,7 +3,6 @@ package com.baeldung.scala.concurrency
 import java.math.BigInteger
 import java.net.URL
 import java.security.MessageDigest
-
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}

--- a/scala-core-2/src/test/scala/com/baeldung/scala/concurrency/FutureAndPromiseUnitTest.scala
+++ b/scala-core-2/src/test/scala/com/baeldung/scala/concurrency/FutureAndPromiseUnitTest.scala
@@ -1,7 +1,8 @@
 package com.baeldung.scala.concurrency
 
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{AsyncFreeSpecLike, Matchers}
+import org.scalatest.freespec.AsyncFreeSpecLike
+import org.scalatest.matchers.should.Matchers
 
 class FutureAndPromiseUnitTest extends AsyncFreeSpecLike with Matchers with ScalaFutures {
   import ScalaAndPromise._

--- a/scala-core-2/src/test/scala/com/baeldung/scala/durationsugar/DurationSugarUnitTest.scala
+++ b/scala-core-2/src/test/scala/com/baeldung/scala/durationsugar/DurationSugarUnitTest.scala
@@ -1,10 +1,11 @@
 package com.baeldung.scala.durationsugar
 
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration.{FiniteDuration, SECONDS}
 
-class DurationSugarUnitTest extends FlatSpec with Matchers {
+class DurationSugarUnitTest extends AnyFlatSpec with Matchers {
 
   "20.seconds" should "equal the object created with the native scala sugar" in {
     20.seconds shouldBe new FiniteDuration(20, SECONDS)

--- a/scala-core-2/src/test/scala/com/baeldung/scala/exceptionhandling/ExceptionHandlingUnitTest.scala
+++ b/scala-core-2/src/test/scala/com/baeldung/scala/exceptionhandling/ExceptionHandlingUnitTest.scala
@@ -1,11 +1,12 @@
 package com.baeldung.scala.exceptionhandling
 
 import com.baeldung.scala.exceptionhandling.ExceptionHandling.{DivideByZero, divideWithEither, divideWithOption, divideWithTry}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.{Failure, Success}
 
-class ExceptionHandlingUnitTest extends FlatSpec with Matchers {
+class ExceptionHandlingUnitTest extends AnyFlatSpec with Matchers {
 
   "divideWithOption" should "return Some when divisor not zero" in {
     divideWithOption(10, 2) should be(Some(5))

--- a/scala-core-2/src/test/scala/com/baeldung/scala/higherkindedtypes/HigherKindedTypesUnitTest.scala
+++ b/scala-core-2/src/test/scala/com/baeldung/scala/higherkindedtypes/HigherKindedTypesUnitTest.scala
@@ -1,9 +1,10 @@
 package com.baeldung.scala.higherkindedtypes
 
-import org.scalatest.{Matchers, WordSpec}
 import com.baeldung.scala.higherkindedtypes.HigherKindedTypes._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class HigherKindedTypesUnitTest extends  WordSpec with Matchers {
+class HigherKindedTypesUnitTest extends AnyWordSpec with Matchers {
 
   "Collections" should {
     "accept any type creator" in {

--- a/scala-core-2/src/test/scala/com/baeldung/scala/implicitclasses/MoneyUnitTest.scala
+++ b/scala-core-2/src/test/scala/com/baeldung/scala/implicitclasses/MoneyUnitTest.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.implicitclasses
 
-import org.scalatest.{Matchers, WordSpec}
-
-class MoneyUnitTest extends WordSpec with Matchers {
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+class MoneyUnitTest extends AnyWordSpec with Matchers {
   val amount: Double = 30.5
 
   "MoneySyntax" should {

--- a/scala-core-2/src/test/scala/com/baeldung/scala/namedanddefaultargs/NamedAndDefaultArgsUnitTest.scala
+++ b/scala-core-2/src/test/scala/com/baeldung/scala/namedanddefaultargs/NamedAndDefaultArgsUnitTest.scala
@@ -1,9 +1,10 @@
 package com.baeldung.scala.namedanddefaultargs
 
 import com.baeldung.scala.namedanddefaultargs.NamedAndDefaultArgs._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class NamedAndDefaultArgsUnitTest extends WordSpec with Matchers {
+class NamedAndDefaultArgsUnitTest extends AnyWordSpec with Matchers {
   "Named and Default Args" should {
     "work with default args" in {
       prettyPrint(Array(1, 2, 3)) shouldBe "(1,2,3)"

--- a/scala-core-2/src/test/scala/com/baeldung/scala/selftype/SelfTypeUnitTest.scala
+++ b/scala-core-2/src/test/scala/com/baeldung/scala/selftype/SelfTypeUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.selftype
 
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class SelfTypeUnitTest extends FlatSpec {
+
+class SelfTypeUnitTest extends AnyFlatSpec {
 
   "TestExecutor class" should "be extended creating a new type" in {
     assertCompiles(

--- a/scala-core-2/src/test/scala/com/baeldung/scala/underscore/UnderscoreUsagesUnitTest.scala
+++ b/scala-core-2/src/test/scala/com/baeldung/scala/underscore/UnderscoreUsagesUnitTest.scala
@@ -1,9 +1,9 @@
 package com.baeldung.scala.underscore
 
 import com.baeldung.scala.underscore.UnderscoreUsages._
-import org.scalatest.{Matchers, WordSpec}
-
-class UnderscoreUsagesUnitTest extends  WordSpec with Matchers {
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+class UnderscoreUsagesUnitTest extends  AnyWordSpec with Matchers {
 
   "The underscore" should {
     "match all types in existential types" in {

--- a/scala-core-3/src/main/scala/com/baeldung/scala/await/AwaitFuture.scala
+++ b/scala-core-3/src/main/scala/com/baeldung/scala/await/AwaitFuture.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.await
 
-import scala.concurrent.{ Await, Future }
-import scala.io.Source
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.io.Source
 
 object AwaitFuture  {
 

--- a/scala-core-3/src/main/scala/com/baeldung/scala/typecasts/ErrorHandling.scala
+++ b/scala-core-3/src/main/scala/com/baeldung/scala/typecasts/ErrorHandling.scala
@@ -2,7 +2,6 @@ package com.baeldung.scala.typecasts
 
 import java.io._
 import java.net._
-
 import scala.io.Source
 import scala.util.{Failure, Success, Try}
 import scala.xml.XML

--- a/scala-core-3/src/test/scala/com/baeldung/scala/accessmodifiers/AccessModifiersUnitTest.scala
+++ b/scala-core-3/src/test/scala/com/baeldung/scala/accessmodifiers/AccessModifiersUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.accessmodifiers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class AccessModifiersUnitTest extends WordSpec with Matchers {
+class AccessModifiersUnitTest extends AnyWordSpec with Matchers {
 
   val rectangle = new Rectangle(3, 4, "gray", 1)
 

--- a/scala-core-3/src/test/scala/com/baeldung/scala/await/AwaitFutureUnitTest.scala
+++ b/scala-core-3/src/test/scala/com/baeldung/scala/await/AwaitFutureUnitTest.scala
@@ -1,14 +1,15 @@
 package com.baeldung.scala.await
 
+import org.scalatest.Ignore
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.{AnyWordSpec, AnyWordSpecLike}
+
 import java.util.concurrent.TimeoutException
-
-import org.scalatest.{ Matchers, WordSpec, Ignore }
-
 import scala.concurrent.duration._
-import scala.concurrent.{ Await, Future }
+import scala.concurrent.{Await, Future}
 
 @Ignore // fixing in JAVA-9842
-class AwaitFutureUnitTest extends AwaitFutureTestUtil {
+class AwaitFutureUnitTest extends AwaitFutureTestUtil with Matchers with AnyWordSpecLike {
 
   private val url = "http://www.baeldung.com"
   "Using Await.ready" should {
@@ -93,7 +94,7 @@ class AwaitFutureUnitTest extends AwaitFutureTestUtil {
 
 }
 
-trait AwaitFutureTestUtil extends WordSpec with Matchers {
+trait AwaitFutureTestUtil extends AnyWordSpec with Matchers {
   //needed to avoid a 403 error
   System.setProperty("http.agent", "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.29 Safari/537.36")
 }

--- a/scala-core-3/src/test/scala/com/baeldung/scala/companionobject/TaskUnitTest.scala
+++ b/scala-core-3/src/test/scala/com/baeldung/scala/companionobject/TaskUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.companionobject
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class TaskUnitTest extends FlatSpec with Matchers {
+class TaskUnitTest extends AnyFlatSpec with Matchers {
 
   "Task" should "be instantiated with default constructor" in {
     val task = new Task("do something")

--- a/scala-core-3/src/test/scala/com/baeldung/scala/dataTypesAndOps/DatatypesAndOpsUnitTest.scala
+++ b/scala-core-3/src/test/scala/com/baeldung/scala/dataTypesAndOps/DatatypesAndOpsUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.dataTypesAndOps
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class DatatypesAndOpsUnitTest extends WordSpec with Matchers  {
+class DatatypesAndOpsUnitTest extends AnyWordSpec with Matchers  {
 
   "Basic  DataTypes of Scala" should {
     "infer the type from assignment " in {

--- a/scala-core-3/src/test/scala/com/baeldung/scala/implicitparameter/ImplicitParameterUnitTest.scala
+++ b/scala-core-3/src/test/scala/com/baeldung/scala/implicitparameter/ImplicitParameterUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.implicitparameter
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ImplicitParameterTest extends WordSpec with Matchers {
+class ImplicitParameterTest extends AnyWordSpec with Matchers {
 
   import ImplicitParameter._
   "Implicit Parameter" should {

--- a/scala-core-3/src/test/scala/com/baeldung/scala/iteratorsvsstreamsvsviews/IteratorVsStreamVsViewUnitTest.scala
+++ b/scala-core-3/src/test/scala/com/baeldung/scala/iteratorsvsstreamsvsviews/IteratorVsStreamVsViewUnitTest.scala
@@ -1,9 +1,9 @@
 package com.baeldung.scala.iteratorsvsstreamsvsviews
 
-import com.baeldung.scala.iteratorsvsstreamsvsviews.NonStrictDataStructures
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class IteratorVsStreamVsViewUnitTest extends WordSpec with Matchers {
+class IteratorVsStreamVsViewUnitTest extends AnyWordSpec with Matchers {
 
   "strict collections after transformations" should {
     "be evaluated immediately" in {

--- a/scala-core-3/src/test/scala/com/baeldung/scala/options/OptionUnitTest.scala
+++ b/scala-core-3/src/test/scala/com/baeldung/scala/options/OptionUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.options
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class OptionUnitTest extends WordSpec with Matchers {
+class OptionUnitTest extends AnyWordSpec with Matchers {
   val tournament: Tournament = new Tournament {
     private val scores = Map("TeamA" -> 11, "TeamB" -> 3, "TeamC" -> 19)
 

--- a/scala-core-3/src/test/scala/com/baeldung/scala/typecasts/TypeErasureUnitTest.scala
+++ b/scala-core-3/src/test/scala/com/baeldung/scala/typecasts/TypeErasureUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.typecasts
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class TypeErasureUnitTest extends  WordSpec with Matchers {
+class TypeErasureUnitTest extends AnyWordSpec with Matchers {
 
   "Generic types" should {
     "be discarded" in {

--- a/scala-core-3/src/test/scala/com/baeldung/scala/typetag/ClassTagExampleUnitTest.scala
+++ b/scala-core-3/src/test/scala/com/baeldung/scala/typetag/ClassTagExampleUnitTest.scala
@@ -1,9 +1,9 @@
 package scala.com.baeldung.scala.typetag
 
 import com.baeldung.scala.typtag.ClassTagExample.makeArrayFrom
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class ClassTagExampleUnitTest extends WordSpec {
+class ClassTagExampleUnitTest extends AnyWordSpec {
   "makeArrayFrom should create array of integer from arbitrary integer numbers" in {
     assert(makeArrayFrom(1, 2, 3) sameElements Array(1, 2, 3))
   }

--- a/scala-core-3/src/test/scala/com/baeldung/scala/typetag/TypeTagExampleUnitTest.scala
+++ b/scala-core-3/src/test/scala/com/baeldung/scala/typetag/TypeTagExampleUnitTest.scala
@@ -1,8 +1,8 @@
 package scala.com.baeldung.scala.typetag
 import com.baeldung.scala.typtag.TypeTagExample.checkType
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class TypeTagExampleUnitTest extends WordSpec {
+class TypeTagExampleUnitTest extends AnyWordSpec {
   val intList: List[Int] = List(1, 2, 3)
   val strList: List[String] = List("foo", "bar")
 

--- a/scala-core-3/src/test/scala/com/baeldung/scala/typetag/WeakTypeTagExampleUnitTest.scala
+++ b/scala-core-3/src/test/scala/com/baeldung/scala/typetag/WeakTypeTagExampleUnitTest.scala
@@ -1,9 +1,9 @@
 package scala.com.baeldung.scala.typetag
 
 import com.baeldung.scala.typtag.WeakTypeTagExample.Foo
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class WeakTypeTagExampleUnitTest extends WordSpec {
+class WeakTypeTagExampleUnitTest extends AnyWordSpec {
   "The compiler should produce implicit WeakTypeTag when calling barType for abstract Bar type" in {
     assert(new Foo {
       override type Bar = Int

--- a/scala-core-4/src/main/scala/com/baeldung/scala/pathdependenttypes/KeyValueStore.scala
+++ b/scala-core-4/src/main/scala/com/baeldung/scala/pathdependenttypes/KeyValueStore.scala
@@ -1,7 +1,6 @@
 package com.baeldung.scala.pathdependenttypes
 
 import java.nio.ByteBuffer
-
 import scala.collection.mutable
 
 abstract class Key(val name: String) {

--- a/scala-core-4/src/test/scala/com/baeldung/scala/assertvsrequire/AssertUsageUnitTest.scala
+++ b/scala-core-4/src/test/scala/com/baeldung/scala/assertvsrequire/AssertUsageUnitTest.scala
@@ -1,9 +1,8 @@
 package com.baeldung.scala.assertvsrequire
-import com.baeldung.scala.assertvsrequire.AssertUsage
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-import org.scalatest.{FlatSpec, Matchers}
-
-class AssertUsageUnitTest extends FlatSpec with Matchers {
+class AssertUsageUnitTest extends AnyFlatSpec with Matchers {
 
   "getSquareOfNumber" should "be able to calculate square of an integer without any error" in {
     noException should be thrownBy AssertUsage.getSquareOfNumber(4)

--- a/scala-core-4/src/test/scala/com/baeldung/scala/assertvsrequire/RequireUsageUnitTest.scala
+++ b/scala-core-4/src/test/scala/com/baeldung/scala/assertvsrequire/RequireUsageUnitTest.scala
@@ -1,9 +1,9 @@
 package com.baeldung.scala.assertvsrequire
 
-import com.baeldung.scala.assertvsrequire.RequireUsage
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class RequireUsageUnitTest extends FlatSpec with Matchers {
+class RequireUsageUnitTest extends AnyFlatSpec with Matchers {
 
   "issueDrivingLicense" should "be able to execute if age is greater than or equal to 18" in {
     noException should be thrownBy RequireUsage.issueDrivingLicense(

--- a/scala-core-4/src/test/scala/com/baeldung/scala/future/FutureRecoveryUnitTest.scala
+++ b/scala-core-4/src/test/scala/com/baeldung/scala/future/FutureRecoveryUnitTest.scala
@@ -1,7 +1,7 @@
 package com.baeldung.scala.future
 
 import com.baeldung.scala.future.FutureRecovery.{Sunny, Windy}
-import org.scalatest.AsyncFlatSpec
+import org.scalatest.flatspec.AsyncFlatSpec
 
 class FutureRecoveryUnitTest extends AsyncFlatSpec {
 

--- a/scala-core-4/src/test/scala/com/baeldung/scala/implicitimports/ImplicitImportsUnitTest.scala
+++ b/scala-core-4/src/test/scala/com/baeldung/scala/implicitimports/ImplicitImportsUnitTest.scala
@@ -1,10 +1,10 @@
 package com.baeldung.scala.implicitimports
 
-import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.exceptions.{TestFailedException, TestCanceledException}
-import scala.util.{Failure, Success}
+import org.scalatest.exceptions.{TestCanceledException, TestFailedException}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ImplicitImportsUnitTest extends FlatSpec with Matchers {
+class ImplicitImportsUnitTest extends AnyFlatSpec with Matchers {
 
   "???" should "return exception" in {
     def notImplemeted:Int => Boolean = ???

--- a/scala-core-4/src/test/scala/com/baeldung/scala/implicitly/ImplicitlyUsageUnitTest.scala
+++ b/scala-core-4/src/test/scala/com/baeldung/scala/implicitly/ImplicitlyUsageUnitTest.scala
@@ -1,9 +1,9 @@
 package com.baeldung.scala.implicitly
 
 import com.baeldung.scala.implicitly.ImplicitlyUsage.{Customer, Policy, searchWithContextBound, searchWithImplicit, weight, weightUsingImplicit, weightUsingImplicitly}
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ImplicitlyUsageUnitTest extends FlatSpec {
+class ImplicitlyUsageUnitTest extends AnyFlatSpec {
 
   "The weight method" should "return the weight of a mass" in {
     val actualWeight: Double = weight(50.0, 9.81)

--- a/scala-core-4/src/test/scala/com/baeldung/scala/pathdependenttypes/KeyValueStoreUnitTest.scala
+++ b/scala-core-4/src/test/scala/com/baeldung/scala/pathdependenttypes/KeyValueStoreUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.pathdependenttypes
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class KeyValueStoreUnitTest extends FlatSpec with Matchers {
+class KeyValueStoreUnitTest extends AnyFlatSpec with Matchers {
 
   "KeyValueStore" should "be able to store typed key with specify the type of the value of that key" in {
     val db = Database()

--- a/scala-core-4/src/test/scala/com/baeldung/scala/structuraltypes/DuckUnitTest.scala
+++ b/scala-core-4/src/test/scala/com/baeldung/scala/structuraltypes/DuckUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.structuraltypes
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DuckUnitTest extends FlatSpec with Matchers {
+class DuckUnitTest extends AnyFlatSpec with Matchers {
   type Flyer = { def fly(): Unit }
   def callFly(thing: Flyer): Unit = thing.fly()
 

--- a/scala-core-4/src/test/scala/com/baeldung/scala/structuraltypes/ResourceClosingUnitTest.scala
+++ b/scala-core-4/src/test/scala/com/baeldung/scala/structuraltypes/ResourceClosingUnitTest.scala
@@ -1,10 +1,12 @@
 package com.baeldung.scala.structuraltypes
 
-import org.scalatest.{FlatSpec, Matchers}
-import scala.jdk.CollectionConverters._
-import scala.io.Source
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ResourceClosingUnitTest extends FlatSpec with Matchers with ResourceClosing {
+import scala.io.Source
+import scala.jdk.CollectionConverters._
+
+class ResourceClosingUnitTest extends AnyFlatSpec with Matchers with ResourceClosing {
   "Scala Sources" should "be closed" in {
      val file = Source.fromResource("animals")
      using(file) {
@@ -16,9 +18,7 @@ class ResourceClosingUnitTest extends FlatSpec with Matchers with ResourceClosin
   }
 
   "Java files" should "be closed" in {
-    import java.io.File
-    import java.io.BufferedReader
-    import java.io.FileReader
+    import java.io.{BufferedReader, File, FileReader}
 
     val resource = getClass.getClassLoader.getResource("animals")
     val file = new FileReader(new File(resource.toURI()))

--- a/scala-core-4/src/test/scala/com/baeldung/scala/typemembersalias/ListIntFunctionsUnitTest.scala
+++ b/scala-core-4/src/test/scala/com/baeldung/scala/typemembersalias/ListIntFunctionsUnitTest.scala
@@ -1,7 +1,8 @@
 package com.baeldung.scala.typemembersalias
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ListIntFunctionsUnitTest extends FlatSpec with Matchers {
+class ListIntFunctionsUnitTest extends AnyFlatSpec with Matchers {
   "Mean function" should "be able to get mean from list of int" in {
     val intList = List(3, 6, 2, 2)
     ListIntFunctions.mean(intList) shouldEqual 3.25

--- a/scala-core-4/src/test/scala/com/baeldung/scala/typemembersalias/RepeatUnitTest.scala
+++ b/scala-core-4/src/test/scala/com/baeldung/scala/typemembersalias/RepeatUnitTest.scala
@@ -1,7 +1,8 @@
 package com.baeldung.scala.typemembersalias
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class RepeatUnitTest extends FlatSpec with Matchers {
+class RepeatUnitTest extends AnyFlatSpec with Matchers {
   "Classes that extend Repeat" should "be able to do integer repetition" in {
     IntegerRepeat(3, 5) shouldEqual 33333
     IntegerRepeat(10, 3) shouldEqual 101010

--- a/scala-core-4/src/test/scala/com/baeldung/scala/uniontypes/ArbitraryArityUnionTypeUnitTest.scala
+++ b/scala-core-4/src/test/scala/com/baeldung/scala/uniontypes/ArbitraryArityUnionTypeUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.uniontypes
-import org.scalatest.{Matchers, FlatSpec}
 import com.baeldung.scala.uniontypes.ArbitraryArityUnionType._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ArbitraryArityUnionTypeUnitTest extends FlatSpec with Matchers {
+class ArbitraryArityUnionTypeUnitTest extends AnyFlatSpec with Matchers {
 
   "isIntOrStringOrBool" should "be able to take an integer parameter" in {
     isIntOrStringOrBool(10) shouldEqual "10 is an Integer"

--- a/scala-core-4/src/test/scala/com/baeldung/scala/uniontypes/EitherDisjointUnionUnitTest.scala
+++ b/scala-core-4/src/test/scala/com/baeldung/scala/uniontypes/EitherDisjointUnionUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.uniontypes
-import org.scalatest.{Matchers, FlatSpec}
 import com.baeldung.scala.uniontypes.EitherDisjointUnion._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class EitherDisjointUnionUnitTest extends FlatSpec with Matchers {
+class EitherDisjointUnionUnitTest extends AnyFlatSpec with Matchers {
   "isIntOrString" should "be able to take an integer parameter" in {
     isIntOrString(Left(10)) shouldEqual "10 is an Integer"
   }

--- a/scala-core-4/src/test/scala/com/baeldung/scala/withfilter/WithFilterVsFilterUnitTest.scala
+++ b/scala-core-4/src/test/scala/com/baeldung/scala/withfilter/WithFilterVsFilterUnitTest.scala
@@ -1,11 +1,12 @@
 package com.baeldung.scala.withfilter
 
-import java.util.concurrent.atomic.AtomicInteger
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
+import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.WithFilter
 
-class WithFilterVsFilterUnitTest extends WordSpec with Matchers {
+class WithFilterVsFilterUnitTest extends AnyWordSpec with Matchers {
 
   sealed trait Level
   object Level {

--- a/scala-core-5/src/main/scala/com/baeldung/scala/datesandtimes/JavaUtilDate.scala
+++ b/scala-core-5/src/main/scala/com/baeldung/scala/datesandtimes/JavaUtilDate.scala
@@ -1,6 +1,5 @@
 package com.baeldung.scala.datesandtimes
 import java.text.SimpleDateFormat
-
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 import scala.languageFeature.experimental.macros

--- a/scala-core-5/src/main/scala/com/baeldung/scala/datesandtimes/JodaTime.scala
+++ b/scala-core-5/src/main/scala/com/baeldung/scala/datesandtimes/JodaTime.scala
@@ -1,9 +1,9 @@
 package com.baeldung.scala.datesandtimes
 
-import java.util.Locale
-
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
+
+import java.util.Locale
 
 object JodaTime extends App{
 

--- a/scala-core-5/src/test/scala/com/baeldung/scala/adt/ExamplesUnitTest.scala
+++ b/scala-core-5/src/test/scala/com/baeldung/scala/adt/ExamplesUnitTest.scala
@@ -1,9 +1,9 @@
 package com.baeldung.scala.adt
 
 import com.baeldung.scala.adt.Examples._
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ExamplesUnitTest extends FlatSpec {
+class ExamplesUnitTest extends AnyFlatSpec {
 
   "isTheMostImportantPiece" should "return true when passing a King" in {
     assert(Examples.isTheMostImportantPiece(ChessPiece(White, King)) == true)

--- a/scala-core-5/src/test/scala/com/baeldung/scala/datesandtimes/JavaTimeUnitTest.scala
+++ b/scala-core-5/src/test/scala/com/baeldung/scala/datesandtimes/JavaTimeUnitTest.scala
@@ -1,8 +1,10 @@
 package com.baeldung.scala.datesandtimes
-import java.time.LocalDate
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class JavaTimeUnitTest extends FlatSpec with Matchers{
+import java.time.LocalDate
+
+class JavaTimeUnitTest extends AnyFlatSpec with Matchers{
   "parseDate" should "be able to parse a date-string using the pattern-input and return a LocalDate object" in {
     val dateStr = "2021-06-13"
     val pattern = "yyyy-MM-dd"

--- a/scala-core-5/src/test/scala/com/baeldung/scala/datesandtimes/JavaUtilDateUnitTest.scala
+++ b/scala-core-5/src/test/scala/com/baeldung/scala/datesandtimes/JavaUtilDateUnitTest.scala
@@ -1,18 +1,20 @@
 package com.baeldung.scala.datesandtimes
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
 import java.text.SimpleDateFormat
 import java.util.Date
 
-import org.scalatest.{FlatSpec, Matchers}
-
-class JavaUtilDateUnitTest extends FlatSpec with Matchers{
+class JavaUtilDateUnitTest extends AnyFlatSpec with Matchers {
   "toDate" should "be able to parse a date-string and return a Date object" in {
     val dateStr = "2021-06-13"
-    val format:ThreadLocal[SimpleDateFormat] = new ThreadLocal[SimpleDateFormat]{
-      override def initialValue = {
-        new SimpleDateFormat("yyyy-MM-dd")
+    val format: ThreadLocal[SimpleDateFormat] =
+      new ThreadLocal[SimpleDateFormat] {
+        override def initialValue = {
+          new SimpleDateFormat("yyyy-MM-dd")
+        }
       }
-    }
-    val expectedDate:Date = new Date(121, 5, 13)
+    val expectedDate: Date = new Date(121, 5, 13)
     JavaUtilDate.toDate(dateStr, format) shouldEqual expectedDate
   }
 }

--- a/scala-core-5/src/test/scala/com/baeldung/scala/datesandtimes/JodaTimeUnitTest.scala
+++ b/scala-core-5/src/test/scala/com/baeldung/scala/datesandtimes/JodaTimeUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.datesandtimes
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class JodaTimeUnitTest extends FlatSpec with Matchers{
+class JodaTimeUnitTest extends AnyFlatSpec with Matchers{
   "parseDate" should "be able to parse a date-string using the pattern-input and return a DateTime object" in {
     val dateStr = "2021-06-13"
     val pattern = "yyyy-MM-dd"

--- a/scala-core-5/src/test/scala/com/baeldung/scala/datesandtimes/NScalaTimeUnitTest.scala
+++ b/scala-core-5/src/test/scala/com/baeldung/scala/datesandtimes/NScalaTimeUnitTest.scala
@@ -1,9 +1,10 @@
 package com.baeldung.scala.datesandtimes
 import com.github.nscala_time.time.Imports._
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class NScalaTimeUnitTest extends FlatSpec with Matchers{
+class NScalaTimeUnitTest extends AnyFlatSpec with Matchers{
   "measureElapsedTimePeriod" should "be able to calculate the time period between starting and ending DateTime objects and  return a Period object" in {
 
     val processStart:DateTime = DateTime.now()

--- a/scala-core-5/src/test/scala/com/baeldung/scala/lambdas/LambdasUnitTest.scala
+++ b/scala-core-5/src/test/scala/com/baeldung/scala/lambdas/LambdasUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.lambdas
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class LambdasUnitTest extends WordSpec with Matchers {
+class LambdasUnitTest extends AnyWordSpec with Matchers {
 
   "A lambda" should {
     "multiply a number by two" in {

--- a/scala-core-5/src/test/scala/com/baeldung/scala/listcreation/ListCreationMethodsUnitTest.scala
+++ b/scala-core-5/src/test/scala/com/baeldung/scala/listcreation/ListCreationMethodsUnitTest.scala
@@ -1,9 +1,10 @@
 package com.baeldung.scala.listcreation
 
-import com.baeldung.scala.listcreation.ListCreationMethods.{createListUsingApply, createListUsingCons, createListUsingFill, createListUsingTabulate, createListUsingToList}
-import org.scalatest.{FlatSpec, Matchers}
+import com.baeldung.scala.listcreation.ListCreationMethods._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ListCreationMethodsUnitTest extends FlatSpec with Matchers{
+class ListCreationMethodsUnitTest extends AnyFlatSpec with Matchers{
 
   "createListUsingCons" should "be able to create a new list using the cons (::) operator" in {
     val listUsingCons = createListUsingCons()

--- a/scala-core-5/src/test/scala/com/baeldung/scala/richwrappers/RichIntUnitTest.scala
+++ b/scala-core-5/src/test/scala/com/baeldung/scala/richwrappers/RichIntUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.richwrappers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class RichIntUnitTest extends WordSpec with Matchers {
+class RichIntUnitTest extends AnyWordSpec with Matchers {
 
   import RichIntImplicits._
 

--- a/scala-core-5/src/test/scala/com/baeldung/scala/richwrappers/RichWrappersUnitTest.scala
+++ b/scala-core-5/src/test/scala/com/baeldung/scala/richwrappers/RichWrappersUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.richwrappers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class RichWrappersUnitTest extends WordSpec with Matchers {
+class RichWrappersUnitTest extends AnyWordSpec with Matchers {
 
   "RichInt" should {
     "format a number in base 2" in {

--- a/scala-core-5/src/test/scala/com/baeldung/scala/richwrappers/SimpleRichUnitTest.scala
+++ b/scala-core-5/src/test/scala/com/baeldung/scala/richwrappers/SimpleRichUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.richwrappers
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class SimpleRichUnitTest extends WordSpec with Matchers {
+class SimpleRichUnitTest extends AnyWordSpec with Matchers {
 
   "SimpleRichInt" should {
     "count the digits of a number" in {

--- a/scala-core-5/src/test/scala/com/baeldung/scala/sorting/SortingUnitTest.scala
+++ b/scala-core-5/src/test/scala/com/baeldung/scala/sorting/SortingUnitTest.scala
@@ -1,9 +1,10 @@
 package com.baeldung.scala.sorting
 
 import org.junit.Test
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class SortingUnitTest extends WordSpec with Matchers {
+class SortingUnitTest extends AnyWordSpec with Matchers {
 
   case class User(name: String, age: Int) extends Ordered[User] {
     override def compare(that: User): Int =

--- a/scala-core-5/src/test/scala/com/baeldung/scala/vectorbenefits/VectorAppendPrependUnitTest.scala
+++ b/scala-core-5/src/test/scala/com/baeldung/scala/vectorbenefits/VectorAppendPrependUnitTest.scala
@@ -1,7 +1,8 @@
 package com.baeldung.scala.vectorbenefits
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class VectorAppendPrependUnitTest extends FlatSpec with Matchers{
+class VectorAppendPrependUnitTest extends AnyFlatSpec with Matchers{
   "appendPrependSeq" should "be able to append or prepend elements to a Sequence" in {
     val vec:Vector[Int] = Vector()
     val numElements = 10000

--- a/scala-core-5/src/test/scala/com/baeldung/scala/vectorbenefits/VectorHeadTailAccessUnitTest.scala
+++ b/scala-core-5/src/test/scala/com/baeldung/scala/vectorbenefits/VectorHeadTailAccessUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.vectorbenefits
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class VectorHeadTailAccessUnitTest extends FlatSpec with Matchers{
+class VectorHeadTailAccessUnitTest extends AnyFlatSpec with Matchers{
   "headTailAccessSeq" should "be able to access head/tail element of a Sequence" in {
     val numElements = 10000
     val vec:Vector[Int] = (1 to numElements).toVector

--- a/scala-core-5/src/test/scala/com/baeldung/scala/vectorbenefits/VectorIterationUnitTest.scala
+++ b/scala-core-5/src/test/scala/com/baeldung/scala/vectorbenefits/VectorIterationUnitTest.scala
@@ -1,6 +1,7 @@
 package com.baeldung.scala.vectorbenefits
-import org.scalatest.{FlatSpec, Matchers}
-class VectorIterationUnitTest extends FlatSpec with Matchers{
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+class VectorIterationUnitTest extends AnyFlatSpec with Matchers{
   "calculateSumSeq" should "be able to calculate sum of all element of a Sequence" in {
 
     val vec:Vector[Int] = Vector(1,2,3,4,5)

--- a/scala-core-6/src/main/scala/com/baeldung/scala/fileio/FileIO.scala
+++ b/scala-core-6/src/main/scala/com/baeldung/scala/fileio/FileIO.scala
@@ -1,7 +1,6 @@
 package com.baeldung.scala.fileio
 
 import java.io._
-
 import scala.util.{Random, Try}
 
 class FileIO {

--- a/scala-core-6/src/main/scala/com/baeldung/scala/functions/Functions.scala
+++ b/scala-core-6/src/main/scala/com/baeldung/scala/functions/Functions.scala
@@ -2,7 +2,6 @@ package com.baeldung.scala.functions
 
 import java.util.Date
 import java.util.concurrent.Executors
-
 import scala.concurrent.{ExecutionContext, Future}
 
 object Functions {

--- a/scala-core-6/src/main/scala/com/baeldung/scala/futures/Futures.scala
+++ b/scala-core-6/src/main/scala/com/baeldung/scala/futures/Futures.scala
@@ -1,7 +1,6 @@
 package com.baeldung.scala.futures
 
 import java.util.concurrent._
-
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}

--- a/scala-core-6/src/test/scala/com/baeldung/scala/implicitconversions/LengthUnitTest.scala
+++ b/scala-core-6/src/test/scala/com/baeldung/scala/implicitconversions/LengthUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.implicitconversions
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class LengthUnitTest extends WordSpec with Matchers {
+class LengthUnitTest extends AnyWordSpec with Matchers {
 
   "Implicit conversion" should {
     import scala.language.implicitConversions

--- a/scala-core-6/src/test/scala/com/baeldung/scala/maps/MapsUnitTest.scala
+++ b/scala-core-6/src/test/scala/com/baeldung/scala/maps/MapsUnitTest.scala
@@ -1,12 +1,12 @@
 //package com.baeldung.scala.maps
 //
 //import java.util.concurrent.atomic.AtomicInteger
-//import org.scalatest.{Matchers, WordSpec}
+//import org.scalatest.matchers.should.Matchers; import org.scalatest.wordspec.AnyWordSpec
 //
 //import scala.collection.immutable.ListMap
 //import scala.collection.{MapView, SortedMap, immutable, mutable}
 //
-//class MapsUnitTest extends WordSpec with Matchers {
+//class MapsUnitTest extends AnyWordSpec with Matchers {
 //
 //  "immutable.Map" should {
 //    val map: Map[Int, String] = immutable.Map((1, "first"), 2 -> "second")

--- a/scala-core-6/src/test/scala/com/baeldung/scala/pimpmylib/PimpLibExampleUnitTest.scala
+++ b/scala-core-6/src/test/scala/com/baeldung/scala/pimpmylib/PimpLibExampleUnitTest.scala
@@ -1,9 +1,9 @@
 package com.baeldung.scala.pimpmylib
 
 import com.baeldung.scala.pimpmylib.PimpLibExample._
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class PimpLibExampleUnitTest extends FlatSpec{
+class PimpLibExampleUnitTest extends AnyFlatSpec{
 
   "Bot" should "detect new member details" in {
     val intro = IntroText(

--- a/scala-core-6/src/test/scala/com/baeldung/scala/ranges/RangeUnitTest.scala
+++ b/scala-core-6/src/test/scala/com/baeldung/scala/ranges/RangeUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.ranges
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class RangeUnitTest extends WordSpec with Matchers {
+class RangeUnitTest extends AnyWordSpec with Matchers {
 
   "Inclusive Range" should {
     "include both start and end of a range" in {

--- a/scala-core-7/src/main/scala/com/baeldung/scala/arrayvswrappedarray/ArrayVsWrappedArray.scala
+++ b/scala-core-7/src/main/scala/com/baeldung/scala/arrayvswrappedarray/ArrayVsWrappedArray.scala
@@ -1,7 +1,7 @@
 package com.baeldung.scala.arrayvswrappedarray
 
-import scala.collection.mutable.WrappedArray
 import scala.collection.ArrayOps
+import scala.collection.mutable.WrappedArray
 
 object ArrayVsWrappedArray extends App {
   private def printSimpleArray(): Unit = {

--- a/scala-core-7/src/test/scala/com/baeldung/scala/arrays/CopyAnArrayToAnotherUnitTest.scala
+++ b/scala-core-7/src/test/scala/com/baeldung/scala/arrays/CopyAnArrayToAnotherUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.arrays
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CopyAnArrayToAnotherUnitTest extends FlatSpec with Matchers {
+class CopyAnArrayToAnotherUnitTest extends AnyFlatSpec with Matchers {
   val array1 = Array(1, 2, 3, 4)
 
   "splat operator" should "copy an entire array to another" in {

--- a/scala-core-7/src/test/scala/com/baeldung/scala/arrays/InitializeAnArrayUnitTest.scala
+++ b/scala-core-7/src/test/scala/com/baeldung/scala/arrays/InitializeAnArrayUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.arrays
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class InitializeAnArrayUnitTest extends FlatSpec with Matchers {
+class InitializeAnArrayUnitTest extends AnyFlatSpec with Matchers {
 
   "new keyword" should "initialize an array of specified size and type" in {
     var array = new Array[Int](4)

--- a/scala-core-7/src/test/scala/com/baeldung/scala/countchar/CountCharsInStringUnitTest.scala
+++ b/scala-core-7/src/test/scala/com/baeldung/scala/countchar/CountCharsInStringUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.countchar
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CountCharsInStringUnitTest extends FlatSpec with Matchers {
+class CountCharsInStringUnitTest extends AnyFlatSpec with Matchers {
   "count with count()" should "correctly count char occurences in String" in {
     val string = "ThisIsAVeryLengthyString"
     val char = 'i';

--- a/scala-core-7/src/test/scala/com/baeldung/scala/typeinference/TypeInferenceLimitationsTest.scala
+++ b/scala-core-7/src/test/scala/com/baeldung/scala/typeinference/TypeInferenceLimitationsTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.typeinference
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class TypeInferenceLimitationsTest extends WordSpec with Matchers {
+class TypeInferenceLimitationsTest extends AnyWordSpec with Matchers {
   "type inference limitations" should {
     import com.baeldung.scala.typeinference.TypeInferenceLimitations._
     "An list of integers given input to recursiveSum function should calculate sum of its elements" in {

--- a/scala-core-7/src/test/scala/com/baeldung/scala/typeinference/TypeInferredFunctionsTest.scala
+++ b/scala-core-7/src/test/scala/com/baeldung/scala/typeinference/TypeInferredFunctionsTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.typeinference
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class TypeInferredFunctionsTest extends WordSpec with Matchers {
+class TypeInferredFunctionsTest extends AnyWordSpec with Matchers {
   "type inference for functions" should {
     import com.baeldung.scala.typeinference.TypeInferredFunctions._
     "An integer number given as input to the function squareInt should calculate its square value, and its return type is inferred as Integer type" in {

--- a/scala-core-7/src/test/scala/com/baeldung/scala/typeinference/TypeInferredVariablesTest.scala
+++ b/scala-core-7/src/test/scala/com/baeldung/scala/typeinference/TypeInferredVariablesTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.typeinference
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class TypeInferredVariablesTest  extends WordSpec with Matchers {
+class TypeInferredVariablesTest  extends AnyWordSpec with Matchers {
   "type inference for variables " should {
     import com.baeldung.scala.typeinference.TypeInferredVariables._
     "An integer number given as initial value should infer a Integer type" in {

--- a/scala-core-8/src/test/scala/com/baeldung/scala/macros/GenericMacrosTest.scala
+++ b/scala-core-8/src/test/scala/com/baeldung/scala/macros/GenericMacrosTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.macros
 
-import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class GenericMacrosTest extends WordSpec with MustMatchers {
+class GenericMacrosTest extends AnyWordSpec with Matchers {
   "generic macro" should {
     "return String for string argument" in {
       GenericMacros.getType("this is a string") mustBe "String"

--- a/scala-core-8/src/test/scala/com/baeldung/scala/macros/OddEvenMacrosTest.scala
+++ b/scala-core-8/src/test/scala/com/baeldung/scala/macros/OddEvenMacrosTest.scala
@@ -1,8 +1,10 @@
 package com.baeldung.scala.macros
 
-import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class OddEvenMacrosTest extends WordSpec with MustMatchers {
+
+class OddEvenMacrosTest extends AnyWordSpec with Matchers {
 
   "def macros" should {
     "return literal odd for odd number" in {

--- a/scala-core-collection-2/src/test/com/baeldung/scala/commoncollections/GetListItemsUnitTest.scala
+++ b/scala-core-collection-2/src/test/com/baeldung/scala/commoncollections/GetListItemsUnitTest.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.commoncollections
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
 
-class GetListItemsUnitTest extends FlatSpec with Matchers {
+class GetListItemsUnitTest extends AnyFlatSpec with Matchers {
   val numbers = List.range(1, 10);
 
   "List.apply" should "return the item at specified index" in {

--- a/scala-core-collection-2/src/test/com/baeldung/scala/commoncollections/ListMapOperationsUnitTest.scala
+++ b/scala-core-collection-2/src/test/com/baeldung/scala/commoncollections/ListMapOperationsUnitTest.scala
@@ -1,10 +1,10 @@
 package com.baeldung.scala.commoncollections
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.immutable.ListMap
 
-class ListMapOperationsUnitTest extends FlatSpec with Matchers {
+class ListMapOperationsUnitTest extends AnyFlatSpec with Matchers {
 
   val countryCapitals: ListMap[String, String] = ListMap(
     "Canada" -> "Ottawa",

--- a/scala-core-collection-2/src/test/com/baeldung/scala/commoncollections/ListSetOperationsUnitTest.scala
+++ b/scala-core-collection-2/src/test/com/baeldung/scala/commoncollections/ListSetOperationsUnitTest.scala
@@ -1,10 +1,10 @@
 package com.baeldung.scala.commoncollections
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.immutable.ListSet
 
-class ListSetOperationsUnitTest extends FlatSpec with Matchers {
+class ListSetOperationsUnitTest extends AnyFlatSpec with Matchers {
 
   val listSet = ListSet(1, 2, 3, 4);
 

--- a/scala-core-collection-2/src/test/com/baeldung/scala/commoncollections/ScalaCollectionsUnitTest.scala
+++ b/scala-core-collection-2/src/test/com/baeldung/scala/commoncollections/ScalaCollectionsUnitTest.scala
@@ -2,7 +2,7 @@ package com.baeldung.scala.commoncollections
 
 import org.scalatest.{Matchers, _}
 
-class ScalaCollectionsUnitTest extends FlatSpec with Matchers {
+class ScalaCollectionsUnitTest extends AnyFlatSpec with Matchers {
 
   "Scala list" should "concatenate using ::: operator" in {
     //given

--- a/scala-core-collections/src/test/scala/com/baedung/scala/collections/FoldingListsUnitTest.scala
+++ b/scala-core-collections/src/test/scala/com/baedung/scala/collections/FoldingListsUnitTest.scala
@@ -1,9 +1,9 @@
 package com.baedung.scala.collections
 
 import com.baeldung.scala.collections.FoldingLists.Person
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class FoldingListsUnitTest extends FlatSpec {
+class FoldingListsUnitTest extends AnyFlatSpec {
 
   val persons = List(Person("Thomas", "male"), Person("Sowell", "male"), Person("Liz", "female"))
 

--- a/scala-core-collections/src/test/scala/com/baedung/scala/collections/IterateMapUnitTest.scala
+++ b/scala-core-collections/src/test/scala/com/baedung/scala/collections/IterateMapUnitTest.scala
@@ -1,9 +1,9 @@
 package com.baedung.scala.collections
 
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 import com.baeldung.scala.collections.IterateMap
 
-class IterateMapUnitTest extends FlatSpec {
+class IterateMapUnitTest extends AnyFlatSpec {
   "Keys" should "return four chars" in {
     assert(IterateMap.keys.size == 4)
     assert(IterateMap.keys.mkString("") == "abcd")

--- a/scala-core-collections/src/test/scala/com/baedung/scala/collections/ListConcatenationUnitTest.scala
+++ b/scala-core-collections/src/test/scala/com/baedung/scala/collections/ListConcatenationUnitTest.scala
@@ -2,6 +2,7 @@ package com.baedung.scala.collections
 
 import org.scalatest.wordspec.AnyWordSpec
 
+
 class ListConcatenationUnitTest extends AnyWordSpec {
 
   private val list1 = 1 :: 2 :: 3 :: Nil

--- a/scala-core-collections/src/test/scala/com/baedung/scala/collections/ParallelCollectionTest.scala
+++ b/scala-core-collections/src/test/scala/com/baedung/scala/collections/ParallelCollectionTest.scala
@@ -1,9 +1,9 @@
 package com.baedung.scala.collections
 
 import com.baeldung.scala.collections.ParallelCollections._
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ParallelCollectionTest extends FlatSpec {
+class ParallelCollectionTest extends AnyFlatSpec {
   val ZERO_TO_HUNDRED_SUM = 5050
   val ZERO_TO_HUNDRED_SUM_TIMES2 = 10100
 

--- a/scala-core-collections/src/test/scala/com/baedung/scala/flattening/FlattenerSpec.scala
+++ b/scala-core-collections/src/test/scala/com/baedung/scala/flattening/FlattenerSpec.scala
@@ -1,5 +1,6 @@
 package com.baedung.scala.flattening
 
+
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.collection.immutable.Queue

--- a/scala-core-collections/src/test/scala/com/baedung/scala/mergemaps/MergeMapsUnitTest.scala
+++ b/scala-core-collections/src/test/scala/com/baedung/scala/mergemaps/MergeMapsUnitTest.scala
@@ -1,9 +1,10 @@
 package com.baedung.scala.mergemaps
 
 import com.baeldung.scala.mergemaps.CombineIterables
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class MergeMapsUnitTest extends FlatSpec with Matchers {
+class MergeMapsUnitTest extends AnyFlatSpec with Matchers {
 
   "++ operator" should "merge maps preferring duplicates from second map" in {
     val firstMap = Map(1 -> "Apple", 5 -> "Banana", 3 -> "Orange");

--- a/scala-core-fp/src/test/scala/com/baeldung/scala/caseobjectsvsenums/CurrencyAdtUnitTest.scala
+++ b/scala-core-fp/src/test/scala/com/baeldung/scala/caseobjectsvsenums/CurrencyAdtUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.caseobjectsvsenums
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CurrencyAdtUnitTest extends FlatSpec with Matchers {
+class CurrencyAdtUnitTest extends AnyFlatSpec with Matchers {
   "The Currency ADT" should "be parsed from a string" in {
     import CurrencyADT._
 

--- a/scala-core-fp/src/test/scala/com/baeldung/scala/caseobjectsvsenums/CurrencyEnumUnitTest.scala
+++ b/scala-core-fp/src/test/scala/com/baeldung/scala/caseobjectsvsenums/CurrencyEnumUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.caseobjectsvsenums
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CurrencyEnumUnitTest extends FlatSpec with Matchers {
+class CurrencyEnumUnitTest extends AnyFlatSpec with Matchers {
   "Enumerations" should "have a collection with all the values" in {
     import CurrencyEnum._
 

--- a/scala-core-fp/src/test/scala/com/baeldung/scala/currying/CurryingUnitTest.scala
+++ b/scala-core-fp/src/test/scala/com/baeldung/scala/currying/CurryingUnitTest.scala
@@ -1,7 +1,7 @@
 package com.baeldung.scala.currying
 
 import org.junit.Test
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 
 class CurryingUnitTest extends Matchers {
 

--- a/scala-core-fp/src/test/scala/com/baeldung/scala/foldvsreduce/FoldLeftVsReduceLeftUnitTest.scala
+++ b/scala-core-fp/src/test/scala/com/baeldung/scala/foldvsreduce/FoldLeftVsReduceLeftUnitTest.scala
@@ -1,9 +1,10 @@
 package com.baeldung.scala.foldvsreduce
 
-import org.scalatest.{Matchers, _}
 import com.baeldung.scala.foldvsreduce.FoldLeftVsReduceLeft.Person
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class FoldLeftVsReduceLeftUnitTest extends FlatSpec with Matchers {
+class FoldLeftVsReduceLeftUnitTest extends AnyFlatSpec with Matchers {
 
   it should "get a list of people from map of id and person" in {
     val people: Map[Int, Person] = Map(1 -> Person("Tom", 10), 2 -> Person("Gillian", 13), 3 -> Person("Sarah", 17), 4 -> Person("David", 20))

--- a/scala-core-fp/src/test/scala/com/baeldung/scala/monad/LazyMonadUnitTest.scala
+++ b/scala-core-fp/src/test/scala/com/baeldung/scala/monad/LazyMonadUnitTest.scala
@@ -1,9 +1,9 @@
 package com.baeldung.scala.monad
 
 import com.baeldung.scala.monad.LazyMonad.Lazy
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class LazyMonadUnitTest extends FlatSpec {
+class LazyMonadUnitTest extends AnyFlatSpec {
   "Lazy.get" should "evaluate and return the internal value" in {
     val lazy42 = Lazy(42)
     assert( lazy42.get == 42)

--- a/scala-core-fp/src/test/scala/com/baeldung/scala/monoid/MapMonoidUnitTest.scala
+++ b/scala-core-fp/src/test/scala/com/baeldung/scala/monoid/MapMonoidUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.monoid
 
 import org.scalatest._
+import org.scalatest.wordspec.AnyWordSpec
 
-class MapMonoidUnitTest extends WordSpec {
+class MapMonoidUnitTest extends AnyWordSpec {
 
   "A Monoid type class" should {
     "combine two Lists using ListMonoidInstance" in {

--- a/scala-core-fp/src/test/scala/com/baeldung/scala/monoid/WordFrequencyCounterUnitTest.scala
+++ b/scala-core-fp/src/test/scala/com/baeldung/scala/monoid/WordFrequencyCounterUnitTest.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.monoid
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class WordFrequencyCounterUnitTest extends WordSpec {
+class WordFrequencyCounterUnitTest extends AnyWordSpec {
 
   object WordFrequencyCounter {
 

--- a/scala-core-fp/src/test/scala/com/baeldung/scala/tagless/TaglessFinalUnitTest.scala
+++ b/scala-core-fp/src/test/scala/com/baeldung/scala/tagless/TaglessFinalUnitTest.scala
@@ -1,9 +1,9 @@
 package com.baeldung.scala.tagless
 
 import com.baeldung.scala.tagless.TaglessFinal.{Product, Program, ProgramWithDep}
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class TaglessFinalUnitTest extends FlatSpec {
+class TaglessFinalUnitTest extends AnyFlatSpec {
 
   "Program.createAndAddToCart" should "create a cart and add a new product using the implicit object resolution" in {
     import com.baeldung.scala.tagless.TaglessFinal.ShoppingCarts._

--- a/scala-core-fp/src/test/scala/com/baeldung/scala/typeclasses/TypeClassExampleUnitTest.scala
+++ b/scala-core-fp/src/test/scala/com/baeldung/scala/typeclasses/TypeClassExampleUnitTest.scala
@@ -2,8 +2,9 @@ package com.baeldung.scala.typeclasses
 
 import com.baeldung.scala.typeclasses.TypeClassExample._
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class TypeClassExampleUnitTest extends FlatSpec{
+class TypeClassExampleUnitTest extends AnyFlatSpec{
   it should "custom print different types" in {
     val studentId = StudentId(25)
     val staffId = StaffId(12)

--- a/scala-core-io/src/test/scala/com/baeldung/scala/io/SourceUnitTest.scala
+++ b/scala-core-io/src/test/scala/com/baeldung/scala/io/SourceUnitTest.scala
@@ -1,11 +1,13 @@
 package com.baeldung.scala.io
 
 
-import org.scalatest.{BeforeAndAfterAll, Matchers, WordSpec}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.io.Source
 
-class SourceUnitTest extends WordSpec with Matchers with BeforeAndAfterAll {
+class SourceUnitTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
   lazy val sourceFromUrl: Source = Source.fromURL("https://google.com")
   lazy val sourceFromClassPath: Source = Source.fromResource("com.baeldung.scala.io/file_in_classpath.txt")
   lazy val sourceFromFile: Source = Source.fromFile("./some_text_file")

--- a/scala-core-oop/src/test/scala/com/baeldung/scala/caseobject/ObjectExampleUnitTest.scala
+++ b/scala-core-oop/src/test/scala/com/baeldung/scala/caseobject/ObjectExampleUnitTest.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.caseobject
 
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ObjectExampleUnitTest extends FlatSpec {
+class ObjectExampleUnitTest extends AnyFlatSpec {
 
   "Bicyle" should "be an instance of Serializable" in {
     assert(Bicycle.isInstanceOf[Serializable])

--- a/scala-core-oop/src/test/scala/com/baeldung/scala/classcompositionwithtraits/CarTraitsUnitTest.scala
+++ b/scala-core-oop/src/test/scala/com/baeldung/scala/classcompositionwithtraits/CarTraitsUnitTest.scala
@@ -1,13 +1,13 @@
 package com.baeldung.scala.classcompositionwithtraits
 
 import com.baeldung.scala.classcompositionwithtraits.CarTraits._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers; import org.scalatest.wordspec.AnyWordSpec
 
 /**
  * @author Sergey Ionin
  */
 
-class CarTraitsUnitTest extends WordSpec with Matchers {
+class CarTraitsUnitTest extends AnyWordSpec with Matchers {
 
   "Class that extends Car" should {
     "inherit abstract class fields" in {

--- a/scala-core-oop/src/test/scala/com/baeldung/scala/lifting/ExamplesUnitTest.scala
+++ b/scala-core-oop/src/test/scala/com/baeldung/scala/lifting/ExamplesUnitTest.scala
@@ -1,9 +1,9 @@
 package com.baeldung.scala.lifting
 
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 import Examples._
 
-class ExamplesUnitTest extends FlatSpec {
+class ExamplesUnitTest extends AnyFlatSpec {
 
   "getSqrtRootMessagePartialFunction" should "calculate square root" in {
     assert(Examples.getSqrtRootMessagePartialFunction(4.0) == "Square root of 4.0 is 2.0")

--- a/scala-core-oop/src/test/scala/com/baeldung/scala/oopinscala/OopConceptsUnitTest.scala
+++ b/scala-core-oop/src/test/scala/com/baeldung/scala/oopinscala/OopConceptsUnitTest.scala
@@ -1,9 +1,10 @@
 package com.baeldung.scala.oopinscala
-import org.scalatest.FunSuite
+
+import org.scalatest.funsuite.AnyFunSuite
 
 import scala.collection.mutable.ArrayBuffer
 
-class OopConceptsUnitTest extends FunSuite {
+class OopConceptsUnitTest extends AnyFunSuite {
   test("access bread fields from object") {
     val whiteBread = new Bread
     assert(whiteBread.name === "white")

--- a/scala-core-oop/src/test/scala/com/baeldung/scala/oopinscala/polymorphism/PolymorphismExamplesUnitTest.scala
+++ b/scala-core-oop/src/test/scala/com/baeldung/scala/oopinscala/polymorphism/PolymorphismExamplesUnitTest.scala
@@ -2,8 +2,9 @@ package com.baeldung.scala.oopinscala.polymorphism
 
 import org.scalatest._
 import PolymorphismExamples._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class PolymorphismExamplesUnitTest extends FlatSpec{
+class PolymorphismExamplesUnitTest extends AnyFlatSpec {
 
   it should "pair-wise reverse an even length int list" in {
     val original = List(1, 2, 3, 4, 5, 6)

--- a/scala-core-oop/src/test/scala/com/baeldung/scala/variance/VarianceUnitTest.scala
+++ b/scala-core-oop/src/test/scala/com/baeldung/scala/variance/VarianceUnitTest.scala
@@ -1,9 +1,9 @@
 package com.baeldung.scala.variance
 
 import com.baeldung.scala.variance.Variance._
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class VarianceUnitTest extends FlatSpec {
+class VarianceUnitTest extends AnyFlatSpec {
 
   "A TestSuite" should "contain both unit and integration tests" in {
     val expected = List(new UnitTest, new IntegrationTest)

--- a/scala-core/src/main/scala/com/baeldung/scala/exceptionhandling/Examples.scala
+++ b/scala-core/src/main/scala/com/baeldung/scala/exceptionhandling/Examples.scala
@@ -1,6 +1,6 @@
 package com.baeldung.scala.exceptionhandling
 
-import scala.util.{Failure, Success, Try, control}
+import scala.util.Try
 import scala.util.control.Exception._
 
 object Examples {

--- a/scala-core/src/main/scala/com/baeldung/scala/exceptionhandling/HandlingWithMonadError.scala
+++ b/scala-core/src/main/scala/com/baeldung/scala/exceptionhandling/HandlingWithMonadError.scala
@@ -1,11 +1,11 @@
 package com.baeldung.scala.exceptionhandling
 
-import cats.MonadError // for MonadError
+import cats.MonadError
 import cats.syntax.flatMap._
 import cats.syntax.functor._
+import com.baeldung.scala.exceptionhandling.LegacyErrors.{ResourceNotFound, ServerError, UserNotFound}
 
 import scala.util.{Failure, Success, Try}
-import com.baeldung.scala.exceptionhandling.LegacyErrors.{ResourceNotFound, ServerError, UserNotFound}
 
 object HandlingWithMonadError {
   def monadErrorAuthenticate[F[_], E] (user: User)(implicit me: MonadError[F, E], adoptError: LegacyErrors => E): F[Session] = {

--- a/scala-core/src/main/scala/com/baeldung/scala/exceptionhandling/HandlingWithValidated.scala
+++ b/scala-core/src/main/scala/com/baeldung/scala/exceptionhandling/HandlingWithValidated.scala
@@ -1,9 +1,9 @@
 package com.baeldung.scala.exceptionhandling
 
 import cats.data.ValidatedNel
-import cats.syntax.validated._
 import cats.syntax.apply._
-import com.baeldung.scala.exceptionhandling.ValidationErrors.{IllegalPassword, IllegalLogin}
+import cats.syntax.validated._
+import com.baeldung.scala.exceptionhandling.ValidationErrors.{IllegalLogin, IllegalPassword}
 
 object HandlingWithValidated {
   type InvalidOr[T] = ValidatedNel[ValidationErrors, T]

--- a/scala-core/src/test/scala/com/baeldung/scala/exceptionhandling/ExamplesUnitTest.scala
+++ b/scala-core/src/test/scala/com/baeldung/scala/exceptionhandling/ExamplesUnitTest.scala
@@ -1,10 +1,11 @@
 package com.baeldung.scala.exceptionhandling
 
-import org.scalatest._
-import org.scalatest.Assertions._
-import scala.util.{Success, Failure}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ExamplesUnitTest extends FlatSpec with Matchers {
+import scala.util.{Failure, Success}
+
+class ExamplesUnitTest extends AnyFlatSpec with Matchers {
 
   "tryCatch" should "handle NegativeNumberException" in {
     noException should be thrownBy Examples.tryCatch(-1, -2)
@@ -40,7 +41,6 @@ class ExamplesUnitTest extends FlatSpec with Matchers {
   }
 
   it should "return the correct sum" in {
-    import CalculatorExceptions._
     val result = Examples.trySuccessFailure(3, 2)
     result match {
       case Failure(e)      => fail("Should succed!")
@@ -67,7 +67,6 @@ class ExamplesUnitTest extends FlatSpec with Matchers {
   }
 
   it should "return the correct sum" in {
-    import CalculatorExceptions._
     val result = Examples.catchObjects(3, 2)
     result match {
       case Failure(e)      => fail("Should succed!")
@@ -92,7 +91,6 @@ class ExamplesUnitTest extends FlatSpec with Matchers {
   }
 
   it should "return the correct sum" in {
-    import CalculatorExceptions._
     val result = Examples.customCatchObjects(3, 2)
     result match {
       case Failure(e)      => fail("Should succed!")
@@ -101,7 +99,6 @@ class ExamplesUnitTest extends FlatSpec with Matchers {
   }
 
   "customCatchObjects composed with trySuccessFailure" should "return the correct sum" in {
-    import CalculatorExceptions._
     val result = Examples.customCatchObjects(3, 2) flatMap (Examples
       .trySuccessFailure(_, 3))
     result match {

--- a/scala-core/src/test/scala/com/baeldung/scala/exceptionhandling/IdiomaticExceptionHandlingUnitTest.scala
+++ b/scala-core/src/test/scala/com/baeldung/scala/exceptionhandling/IdiomaticExceptionHandlingUnitTest.scala
@@ -1,16 +1,17 @@
 package com.baeldung.scala.exceptionhandling
 
-import java.io.IOException
-
 import cats.data.NonEmptyList
 import cats.data.Validated.{Invalid, Valid}
 import com.baeldung.scala.exceptionhandling.LegacyErrors.{ResourceNotFound, ServerError, UserNotFound}
 import com.baeldung.scala.exceptionhandling.ValidationErrors.{IllegalLogin, IllegalPassword}
-import org.scalatest.{FeatureSpec, FlatSpec, GivenWhenThen, Matchers}
+import org.scalatest.GivenWhenThen
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.should.Matchers
 
+import java.io.IOException
 import scala.util.{Failure, Success, Try}
 
-class IdiomaticExceptionHandlingUnitTest extends FeatureSpec with GivenWhenThen  with Matchers {
+class IdiomaticExceptionHandlingUnitTest extends AnyFeatureSpec with GivenWhenThen  with Matchers {
   val user = User("user1", "password1")
   val rootUser = User("root", "root_password")
 

--- a/scala-core/src/test/scala/com/baeldung/scala/forloop/ForLoopUnitTest.scala
+++ b/scala-core/src/test/scala/com/baeldung/scala/forloop/ForLoopUnitTest.scala
@@ -1,6 +1,5 @@
 package com.baeldung.scala.forloop
 
-import com.baeldung.scala.forloop.ForLoop
 import org.junit.Assert.assertEquals
 import org.junit.{Before, Test}
 

--- a/scala-core/src/test/scala/com/baeldung/scala/lazyval/LazyValUnitTest.scala
+++ b/scala-core/src/test/scala/com/baeldung/scala/lazyval/LazyValUnitTest.scala
@@ -1,14 +1,13 @@
 package com.baeldung.scala.lazyval
 
-import org.scalatest.FunSuite
-import org.scalatest.Matchers._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
-import scala.concurrent.{Future, _}
-import com.baeldung.scala.lazyval
+import scala.concurrent._
 
-class LazyValUnitTest extends FunSuite {
+class LazyValUnitTest extends AnyFunSuite {
 
   test("lazy val is computed only once") {
     //given

--- a/scala-core/src/test/scala/com/baeldung/scala/partialfunctions/SquareRootUnitTest.scala
+++ b/scala-core/src/test/scala/com/baeldung/scala/partialfunctions/SquareRootUnitTest.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.partialfunctions
 
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class SquareRootUnitTest extends FlatSpec {
+class SquareRootUnitTest extends AnyFlatSpec {
 
   "SquareRoot" should "return the correct value for positive double" in {
     assert(SquareRoot.squareRoot(4.0) == 2.0)

--- a/scala-core/src/test/scala/com/baeldung/scala/partialfunctions/SwapIntegerSignUnitTest.scala
+++ b/scala-core/src/test/scala/com/baeldung/scala/partialfunctions/SwapIntegerSignUnitTest.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.partialfunctions
 
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class SwapIntegerSignUnitTest extends FlatSpec {
+class SwapIntegerSignUnitTest extends AnyFlatSpec {
 
   "swapSign" should "return a positive number when a negative is given" in {
     assert(SwapIntegerSign.swapSign(-3) == 3)

--- a/scala-core/src/test/scala/com/baeldung/scala/tuples/TuplesUnitTest.scala
+++ b/scala-core/src/test/scala/com/baeldung/scala/tuples/TuplesUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.tuples
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class TuplesUnitTest extends WordSpec with Matchers {
+class TuplesUnitTest extends AnyWordSpec with Matchers {
   val tuple = ("Joe", 34)
 
   "Tuples" should {

--- a/scala-design-patterns/src/test/scala/com/baeldung/scala/cakepattern/CakePatternUnitTest.scala
+++ b/scala-design-patterns/src/test/scala/com/baeldung/scala/cakepattern/CakePatternUnitTest.scala
@@ -2,7 +2,7 @@ package com.baeldung.scala.cakepattern
 
 import com.baeldung.scala.cakepattern.CakePattern.Test
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
 trait TestRegistry
   extends CakePattern.TestExecutorComponent
@@ -12,7 +12,7 @@ trait TestRegistry
   override val testExecutor: TestExecutor = new TestExecutor
 }
 
-class CakePatternUnitTest extends FlatSpec with TestRegistry {
+class CakePatternUnitTest extends AnyFlatSpec with TestRegistry {
 
   "A TestExecutor" should "execute tests using a given environment" in {
     (env.readEnvironmentProperties _).expects().returning(Map("ENV" -> "true"))

--- a/scala-design-patterns/src/test/scala/com/baeldung/scala/magnetpattern/MagnetPatternTest.scala
+++ b/scala-design-patterns/src/test/scala/com/baeldung/scala/magnetpattern/MagnetPatternTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.magnetpattern
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class MagnetPatternTest extends FlatSpec with Matchers{
+class MagnetPatternTest extends AnyFlatSpec with Matchers{
   "combineElements" should "be able to combine the elements in a collection" in {
     val intList = List(1,2,3,4)
     val strList = List("a","b","c")

--- a/scala-lang-2/src/main/scala/com/baeldung/scala/withtrait/Animal.scala
+++ b/scala-lang-2/src/main/scala/com/baeldung/scala/withtrait/Animal.scala
@@ -1,0 +1,6 @@
+package com.baeldung.scala.withtrait
+
+class Animal(name: String, species: String) {
+  def makeNoise(noise: String): String =
+    s"I'm $name (a $species) making this noise: $noise"
+}

--- a/scala-lang-2/src/main/scala/com/baeldung/scala/withtrait/Musician.scala
+++ b/scala-lang-2/src/main/scala/com/baeldung/scala/withtrait/Musician.scala
@@ -1,0 +1,11 @@
+package com.baeldung.scala.withtrait
+
+trait Musician {
+  val instrument: String
+
+  def tuneInstrument(): String =
+    s"I'm tuning my $instrument"
+
+  def playSong(song: String): String =
+    s"I'm playing the beautiful song $song"
+}

--- a/scala-lang-2/src/main/scala/com/baeldung/scala/withtrait/Person.scala
+++ b/scala-lang-2/src/main/scala/com/baeldung/scala/withtrait/Person.scala
@@ -1,0 +1,13 @@
+package com.baeldung.scala.withtrait
+
+import java.time.LocalDate
+
+class Person(name: String, address: String, dateOfBirth: LocalDate) {
+  def breathe(): String = s"I'm $name, alive and kicking"
+
+  def eat(): String = "I'm eating: chomp chomp"
+
+  def walk(): String = "I'm walking: away I go"
+
+  def saySomething(what: String): String = s"I say: $what"
+}

--- a/scala-lang-2/src/main/scala/com/baeldung/scala/withtrait/Politician.scala
+++ b/scala-lang-2/src/main/scala/com/baeldung/scala/withtrait/Politician.scala
@@ -1,0 +1,9 @@
+package com.baeldung.scala.withtrait
+
+trait Politician {
+  def vote(): String =
+    "I'm voting"
+
+  def saySpeech(speech: String): String =
+    s"I'm saying an important speech: $speech"
+}

--- a/scala-lang-2/src/test/scala/com/baeldung/scala/withtrait/WithTraitSpec.scala
+++ b/scala-lang-2/src/test/scala/com/baeldung/scala/withtrait/WithTraitSpec.scala
@@ -1,0 +1,78 @@
+package com.baeldung.scala.withtrait
+
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.time.LocalDate
+
+class WithTraitSpec extends AnyWordSpec {
+
+  import WithTraitSpec._
+
+  "A person should" should {
+    "know how to breathe and say their name" in {
+      assertResult("I'm Pat, alive and kicking")(pat.breathe())
+    }
+  }
+
+  "A musician" should {
+    "know their name, as a person" in {
+      assertResult("I'm Mary, alive and kicking")(mary.breathe())
+    }
+    "tune their instrument" in {
+      assertResult("I'm tuning my guitar")(mary.tuneInstrument())
+    }
+  }
+
+  "A politician" should {
+    "know their name, as a person" in {
+      assertResult("I'm Prudence, alive and kicking")(prudence.breathe())
+    }
+    "say an important speech, as a politician" in {
+      assertResult("I'm saying an important speech: blah, blah, blah...")(
+        prudence.saySpeech("blah, blah, blah...")
+      )
+    }
+  }
+
+  "A musician/politician" should {
+    "know their name, as a person" in {
+      assertResult("I'm Giorgio, alive and kicking")(giorgio.breathe())
+    }
+    "cast a vote, as a politician" in {
+      assertResult("I'm voting")(giorgio.vote())
+    }
+    "play a song" in {
+      assertResult("I'm playing the beautiful song #1")(giorgio.playSong("#1"))
+    }
+  }
+}
+
+object WithTraitSpec {
+  val pat: Person =
+    new Person("Pat", "123 Main St.", LocalDate.of(1933, 10, 11))
+
+  val mary: Person with Musician =
+    new Person("Mary", "456 Second St.", LocalDate.of(1982, 9, 9))
+      with Musician {
+      override val instrument: String = "guitar"
+    }
+
+  val prudence: Person with Politician =
+    new Person("Prudence", "789 Third St.", LocalDate.of(1972, 6, 3))
+      with Politician
+
+  val giorgio: Person with Politician with Musician =
+    new Person("Giorgio", "121 Fourth St.", LocalDate.of(1980, 2, 19))
+      with Politician
+      with Musician {
+      override val instrument: String = "flute"
+    }
+
+  val ellie: Animal with Musician =
+    new Animal("Ellie", "elephant") with Musician {
+      override val instrument: String = "trombone"
+    }
+
+  val vasily: Animal with Politician =
+    new Animal("Vasily", "monkey") with Politician
+}

--- a/scala-lang/src/main/scala/com/baeldung/scala/packageimport/Importing.scala
+++ b/scala-lang/src/main/scala/com/baeldung/scala/packageimport/Importing.scala
@@ -1,12 +1,7 @@
 package com.baeldung.scala.packageimport
-
-import com.baeldung.scala.packageimport.vehicle.Bicycle
 // import every class in a package
-import com.baeldung.scala.packageimport.vehicle._
 // import multiple classes from a package
-import com.baeldung.scala.packageimport.vehicle.{Bicycle, Car, Vehicle}
-
-import com.baeldung.scala.packageimport.vehicle.{Bicycle => BC, Car, Vehicle}
+import com.baeldung.scala.packageimport.vehicle.{Car, Bicycle => BC}
 
 object Importing extends App {
   val firstBicycle: BC = new BC(2, "Abici")

--- a/scala-lang/src/main/scala/com/baeldung/scala/packageimport/vehicle/Bicycle.scala
+++ b/scala-lang/src/main/scala/com/baeldung/scala/packageimport/vehicle/Bicycle.scala
@@ -1,7 +1,7 @@
 package com.baeldung.scala.packageimport.vehicle
 
-import java.util.{Date => _, _}
 import java.sql.Date
+import java.util.{Date => _}
 
 class Bicycle(numberOfTires: Int, brand: String) extends Vehicle(numberOfTires, brand) {
   override def run(): Unit = {

--- a/scala-lang/src/main/scala/com/baeldung/scala/packageimport/vehicle/Vehicle.scala
+++ b/scala-lang/src/main/scala/com/baeldung/scala/packageimport/vehicle/Vehicle.scala
@@ -1,7 +1,7 @@
 package com.baeldung.scala.packageimport.vehicle {
 
-  import java.util.{Date => utilDate}
   import java.sql.{Date => sqlDate}
+  import java.util.{Date => utilDate}
 
   abstract class Vehicle(numberOfTires: Int, brand: String) {
 

--- a/scala-lang/src/test/scala/com/baeldung/scala/callbynameandvalue/CallByNameCallByValueUnitTest.scala
+++ b/scala-lang/src/test/scala/com/baeldung/scala/callbynameandvalue/CallByNameCallByValueUnitTest.scala
@@ -1,7 +1,5 @@
 package com.baeldung.scala.callbynameandvalue
 
-import java.lang.Thread.sleep
-
 import com.baeldung.scala.callbynameandvalue.CallByNameCallByValue._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/scala-lang/src/test/scala/com/baeldung/scala/conditional/ScalaConditionalExpressionsUnitTest.scala
+++ b/scala-lang/src/test/scala/com/baeldung/scala/conditional/ScalaConditionalExpressionsUnitTest.scala
@@ -1,9 +1,10 @@
 package com.baeldung.scala.conditional
 
 import com.baeldung.scala.conditional.ScalaConditionalExpressions.max
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ScalaConditionalExpressionsUnitTest extends FlatSpec with Matchers {
+class ScalaConditionalExpressionsUnitTest extends AnyFlatSpec with Matchers {
 
     "max" should "return maximum of two numbers" in {
         max(10, 20) should be(20)

--- a/scala-lang/src/test/scala/com/baeldung/scala/equality/EqualityUnitTest.scala
+++ b/scala-lang/src/test/scala/com/baeldung/scala/equality/EqualityUnitTest.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.equality
 
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 
-class EqualityUnitTest extends FlatSpec {
+class EqualityUnitTest extends AnyFlatSpec {
   "Equality operator for AnyVal" should "work as in Java" in {
     val intAnyVal = 4
     assert(intAnyVal == 2 * 2)

--- a/scala-lang/src/test/scala/com/baeldung/scala/functionsandmethods/FunctionsAndMethodsUnitTest.scala
+++ b/scala-lang/src/test/scala/com/baeldung/scala/functionsandmethods/FunctionsAndMethodsUnitTest.scala
@@ -1,7 +1,7 @@
 package com.baeldung.scala.functionsandmethods
 
 import org.junit.Assert.assertEquals
-import org.junit.{Before, Test}
+import org.junit.Test
 
 import scala.util.Random
 

--- a/scala-lang/src/test/scala/com/baeldung/scala/mutability/ImmutabilityCarUnitTest.scala
+++ b/scala-lang/src/test/scala/com/baeldung/scala/mutability/ImmutabilityCarUnitTest.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.mutability
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ImmutabilityCarUnitTest extends FunSuite {
+class ImmutabilityCarUnitTest extends AnyFunSuite {
   test("Mutable vs Immutable variables") {
     val pi = 3.14
     // pi = 4 // Compile error: Reassignment to val

--- a/scala-lang/src/test/scala/com/baeldung/scala/mutability/ImmutableCollectionsUnitTest.scala
+++ b/scala-lang/src/test/scala/com/baeldung/scala/mutability/ImmutableCollectionsUnitTest.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.mutability
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
 
-class ImmutableCollectionsUnitTest extends FunSuite {
+class ImmutableCollectionsUnitTest extends AnyFunSuite {
   test("Immutable collections will create new instance if we add or update the elements") {
     val pets = Seq("Cat", "Dog")
     val myPets = pets :+ "Hamster"

--- a/scala-lang/src/test/scala/com/baeldung/scala/mutability/MutableCollectionsUnitTest.scala
+++ b/scala-lang/src/test/scala/com/baeldung/scala/mutability/MutableCollectionsUnitTest.scala
@@ -1,9 +1,10 @@
 package com.baeldung.scala.mutability
 
-import org.scalatest.FunSuite
+import org.scalatest.funsuite.AnyFunSuite
+
 import scala.collection.mutable.ArrayBuffer
 
-class MutableCollectionsUnitTest extends FunSuite {
+class MutableCollectionsUnitTest extends AnyFunSuite {
   test("Mutable collection can be added with new elements") {
     val breakfasts = ArrayBuffer("Sandwich", "Salad")
 

--- a/scala-lang/src/test/scala/com/baeldung/scala/typehierarchy/TypeHierarchyUnitTest.scala
+++ b/scala-lang/src/test/scala/com/baeldung/scala/typehierarchy/TypeHierarchyUnitTest.scala
@@ -1,13 +1,14 @@
 package com.baeldung.scala.typehierarchy
 
 import com.baeldung.scala.typehierarchy.TypeHierarchy._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * @author vid2010
  */
 
-class TypeHierarchyUnitTest extends FlatSpec with Matchers {
+class TypeHierarchyUnitTest extends AnyFlatSpec with Matchers {
 
   "A Any type" should "compatible with any type" in {
     assert(any(1) == "")

--- a/scala-libraries-2/src/test/scala/com/baeldung/enumeratum/EnumeratumUnitTest.scala
+++ b/scala-libraries-2/src/test/scala/com/baeldung/enumeratum/EnumeratumUnitTest.scala
@@ -1,9 +1,9 @@
 package com.baeldung.enumeratum
 
-import org.scalatest.WordSpec
-import org.scalatest.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class EnumeratumUnitTest extends WordSpec with Matchers {
+class EnumeratumUnitTest extends AnyWordSpec with Matchers {
   "Enumeratum" should {
 
     "create and parse Country enums" in {

--- a/scala-libraries-2/src/test/scala/com/baeldung/scala/monix/MonixTaskUnitTest.scala
+++ b/scala-libraries-2/src/test/scala/com/baeldung/scala/monix/MonixTaskUnitTest.scala
@@ -1,10 +1,12 @@
 package com.baeldung.scala.monix
 
 import monix.execution.schedulers.TestScheduler
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
 import scala.util.Success
 
-class MonixTaskUnitTest extends FlatSpec with Matchers{
+class MonixTaskUnitTest extends AnyFlatSpec with Matchers{
   import MonixTask.sampleMonixTask
   "sampleMonixTask" should "be able to create and return a Task which adds two integer parameters" in {
     implicit val s:TestScheduler = TestScheduler()

--- a/scala-libraries-3/src/test/scala/com/baeldung/scala/retry/PrimeNumberRetryTest.scala
+++ b/scala-libraries-3/src/test/scala/com/baeldung/scala/retry/PrimeNumberRetryTest.scala
@@ -1,7 +1,7 @@
 package com.baeldung.scala.retry
 
 import com.baeldung.scala.retry.PrimeNumberRetry.success
-import org.scalatest.matchers.must.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AsyncWordSpec
 
 import java.util.concurrent.atomic.AtomicInteger

--- a/scala-libraries-3/src/test/scala/com/baeldung/scala/spark/rdd/PrintRDDTest.scala
+++ b/scala-libraries-3/src/test/scala/com/baeldung/scala/spark/rdd/PrintRDDTest.scala
@@ -2,9 +2,9 @@ package com.baeldung.scala.spark.rdd
 
 import org.apache.spark.sql.SparkSession
 import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.must.Matchers.{a, convertToAnyMustWrapper}
+import org.scalatest.matchers.must.Matchers
 
-class PrintRDDTest extends AnyFlatSpec {
+class PrintRDDTest extends AnyFlatSpec with Matchers {
   val spark: SparkSession = SparkSession.builder.master("local").getOrCreate
 
   "default rdd" should "have size six" in {

--- a/scala-libraries-4/README.md
+++ b/scala-libraries-4/README.md
@@ -1,3 +1,5 @@
 ## Relevant Articles
+
 - [Introduction to uTest](https://www.baeldung.com/scala/utest-intro)
 - [Introduction to scala-async](https://www.baeldung.com/scala/scala-async)
+- [Get the First N Rows of a Spark Dataframe](https://www.baeldung.com/scala/spark-dataframe-get-first-n-rows)

--- a/scala-libraries-4/src/main/scala/com/baeldung/scala/spark/FirstNRows.scala
+++ b/scala-libraries-4/src/main/scala/com/baeldung/scala/spark/FirstNRows.scala
@@ -1,0 +1,66 @@
+package com.baeldung.scala.spark
+import sparkUtil.getSpark
+
+object info {
+  val spark = getSpark("FirstNRows")
+  import spark.implicits._
+
+  val data = Seq(
+    ("Ann", 25),
+    ("Brian", 16),
+    ("Jack", 35),
+    ("Conrad", 27),
+    ("Grace", 33),
+    ("Richard", 40)
+  ).toDF("Name", "Age")
+}
+
+object FirstNRows extends App {
+  import info.data
+  import info.spark
+
+  data.show(3)
+
+  /** | Name  | Age |
+    * |:------|:----|
+    * | Ann   | 25  |
+    * | Brian | 16  |
+    * | Jack  | 35  |
+    * only showing top 3 rows
+    */
+
+  data.head(2).foreach(println)
+
+  /** [Ann,25] [Brian,16]
+    */
+
+  data.take(2).foreach(println)
+
+  /** [Ann,25] [Brian,16]
+    */
+
+  println(data.takeAsList(2))
+
+  /** [[Ann,25], [Brian,16]]
+    */
+
+  data.limit(2).foreach(println(_))
+
+  /** [Ann,25] [Brian,16]
+    */
+
+  data.limit(2).show()
+
+  /** | Name  | Age |
+    * |:------|:----|
+    * | Ann   | 25  |
+    * | Brian | 16  |
+    */    
+
+  println(data.first())
+
+  /** [Ann,25]
+    */
+
+  spark.close()
+}

--- a/scala-libraries-4/src/main/scala/com/baeldung/scala/spark/firstNRows/sparkUtility.scala
+++ b/scala-libraries-4/src/main/scala/com/baeldung/scala/spark/firstNRows/sparkUtility.scala
@@ -1,0 +1,11 @@
+package com.baeldung.scala.spark
+import org.apache.spark.sql.SparkSession
+
+object sparkUtil {
+  def getSpark(Name: String, Master: String = "local", partNo: String = "5", verbose:Boolean = true): SparkSession = {
+    val sparkSession = SparkSession.builder().appName(Name).master(Master).getOrCreate()
+    sparkSession.conf.set("spark.sql.shuffle.partitions", partNo)
+    if(verbose) println(s"Session started on spark version ${sparkSession.version}")
+    return sparkSession
+  }
+}

--- a/scala-libraries-4/src/test/scala/com/baeldung/scala/skunk/Session.scala
+++ b/scala-libraries-4/src/test/scala/com/baeldung/scala/skunk/Session.scala
@@ -1,0 +1,70 @@
+package com.baeldung.scala.skunk
+
+import cats.effect.{IO, IOApp}
+import cats.effect.kernel.Resource
+import skunk.{Query, Session}
+import cats.effect._
+import natchez.Trace.Implicits.noop
+import skunk._
+import skunk.implicits._
+import skunk.codec.all._
+
+object Skunk{
+  case class User(id: Int, username: String, email: String, age:Int)
+
+  def createSession(): Resource[IO, Session[IO]] =
+    Session.single[IO]( host = "localhost",
+      user = "baeldung",
+      database = "baeldung",
+      password = Some("baeldung"),
+      port = 5432
+    )
+
+  def getAllUsers(resource: Resource[IO, Session[IO]]) = {
+    val query: Query[Void, Int ~ String ~ String ~ Int] =
+      sql"SELECT * FROM Users"
+      .query(int4 ~ varchar(255) ~ varchar(255) ~ int4)
+
+    val mappedQuery: Query[Void, User] = query
+      .gmap[User]
+    val results: IO[List[User]] = resource.use(s => s.execute(mappedQuery))
+    results
+  }
+
+  def getUserWithId(resource: Resource[IO, Session[IO]]) = {
+    val query:Query[Int ~ String, User]  =
+      sql"""
+        SELECT * FROM Users WHERE
+          id = $int4 AND username LIKE $varchar
+       """
+      .query(int4 ~ varchar(255) ~ varchar(255) ~ int4)
+      .gmap[User]
+
+   val preparedQuery: Resource[IO, PreparedQuery[IO, Int ~ String, User]] =  resource
+      .flatMap(session => session.prepare(query))
+
+    preparedQuery.use(pq => pq.unique(1, "baeldungUser"))
+  }
+
+  def removeUserWithId(resource: Resource[IO, Session[IO]]) = {
+    val command: Command[Void]  =
+      sql"""
+        DELETE FROM Users WHERE
+          id = 5
+       """
+        .command
+
+    resource.use(session => session.execute(command))
+  }
+
+  def removePrepared(resource: Resource[IO, Session[IO]]) = {
+    val command: Command[Int ~ String]  =
+      sql"""
+        DELETE FROM Users WHERE
+          id = $int4 and username = $varchar
+       """
+        .command
+    resource.flatMap(session => session.prepare(command))
+      .use(pc => pc.execute((1, "baeldungUser")))
+  }
+}

--- a/scala-libraries-4/src/test/scala/com/baeldung/scala/spark/FirstNRowsTest.scala
+++ b/scala-libraries-4/src/test/scala/com/baeldung/scala/spark/FirstNRowsTest.scala
@@ -1,0 +1,54 @@
+package com.baeldung.scala.spark
+import sparkUtil.getSpark
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.apache.spark.sql.types.{StringType, IntegerType}
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.Dataset
+import info.{data, spark}
+import spark.implicits._
+
+class FirstNRowsSpec extends AnyFlatSpec with Matchers {
+
+  "The data Dataframe" should "contain 6 elements" in {
+    data.count() shouldBe (6)
+  }
+
+  it should "contain columns Name and Age" in {
+    data.columns(0) shouldBe ("Name")
+    data.columns(1) shouldBe ("Age")
+  }
+
+  it should "contain columns of type StringType and IntegerType" in {
+    data.schema("Name").dataType shouldBe an[StringType]
+    data.schema("Age").dataType shouldBe an[IntegerType]
+  }
+
+  "The show() method" should "return a Unit value" in {
+    data.show() shouldBe an[Unit]
+  }
+
+  "The head(2) method" should "return first 2 rows of the data Dataframe" in {
+    data.head(2) shouldBe (Array(
+      Row("Ann", 25),
+      Row("Brian", 16)
+    ))
+  }
+
+  "The take(3) method" should "return the first 3 rows of the data Dataframe" in {
+    data.take(3) shouldBe (Array(
+      Row("Ann", 25),
+      Row("Brian", 16),
+      Row("Jack", 35)
+    ))
+  }
+
+  "The limit(2) method" should "return a new DataSet with first 2 elements" in {
+    data.limit(2) shouldBe an[Dataset[Row]]
+    data.limit(2).count() shouldBe (2)
+  }
+
+  "The first() method" should "return the first row of the data Dataframe" in {
+    data.first() shouldBe (Row("Ann", 25))
+  }
+}

--- a/scala-libraries/src/test/scala/com/baeldung/scala/cats/ShapeAreaSyntaxUnitTest.scala
+++ b/scala-libraries/src/test/scala/com/baeldung/scala/cats/ShapeAreaSyntaxUnitTest.scala
@@ -1,9 +1,10 @@
 import AreaInstances._
 import ShapeAreaSyntax._
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class ShapeAreaSyntaxUnitTest extends FlatSpec with Matchers {
+class ShapeAreaSyntaxUnitTest extends AnyFlatSpec with Matchers {
   "ShapeAreaSyntaxSpec" should "check for candidate type class instance for type Rectangle" in {
     val areaOfRectangle = Rectangle(2, 3).areaOf
     val expectedAreaOfRectangle = 6.0

--- a/scala-libraries/src/test/scala/com/baeldung/scala/cats/ShapeAreaUnitTest.scala
+++ b/scala-libraries/src/test/scala/com/baeldung/scala/cats/ShapeAreaUnitTest.scala
@@ -1,8 +1,9 @@
 import AreaInstances._
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class ShapeAreaUnitTest extends FlatSpec with Matchers{
+class ShapeAreaUnitTest extends AnyFlatSpec with Matchers{
   val rectangle: Rectangle = Rectangle(2, 3)
   val circle: Circle = Circle(2)
 

--- a/scala-libraries/src/test/scala/com/baeldung/scala/cats/show/CustomInstanceUnitTest.scala
+++ b/scala-libraries/src/test/scala/com/baeldung/scala/cats/show/CustomInstanceUnitTest.scala
@@ -1,13 +1,13 @@
 package com.baeldung.scala.cats.show
 
 import java.util.Date
-
 import cats.Show
 import cats.implicits._
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class CustomInstanceUnitTest extends FlatSpec with Matchers {
+class CustomInstanceUnitTest extends AnyFlatSpec with Matchers {
   implicit val customShow: Show[Date] =
     (date: Date) => s"This year is: ${date.getYear}"
 

--- a/scala-libraries/src/test/scala/com/baeldung/scala/cats/show/InterfaceSyntaxUnitTest.scala
+++ b/scala-libraries/src/test/scala/com/baeldung/scala/cats/show/InterfaceSyntaxUnitTest.scala
@@ -2,9 +2,10 @@ package com.baeldung.scala.cats.show
 
 import cats.implicits._
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class InterfaceSyntaxUnitTest extends FlatSpec with Matchers {
+class InterfaceSyntaxUnitTest extends AnyFlatSpec with Matchers {
   "InterfaceSyntax" should "show string of integer" in {
     assert(123.show == "123")
   }

--- a/scala-libraries/src/test/scala/com/baeldung/scala/cats/show/ShowImplUnitTest.scala
+++ b/scala-libraries/src/test/scala/com/baeldung/scala/cats/show/ShowImplUnitTest.scala
@@ -3,9 +3,10 @@ package com.baeldung.scala.cats.show
 import cats.Show
 import cats.implicits._
 import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class ShowImplUnitTest extends FlatSpec with Matchers {
+class ShowImplUnitTest extends AnyFlatSpec with Matchers {
   val showInt: Show[Int] = Show.apply[Int]
   val showString: Show[String] = Show.apply[String]
 

--- a/scala-libraries/src/test/scala/com/baeldung/scala/monocle/OpticsExamplesUnitTest.scala
+++ b/scala-libraries/src/test/scala/com/baeldung/scala/monocle/OpticsExamplesUnitTest.scala
@@ -2,10 +2,13 @@ package com.baeldung.scala.monocle
 
 import org.scalatest._
 import org.scalatest.Assertions._
-import scala.util.{Success, Failure}
-import OpticsExamples._
 
-class OpticsExamplesUnitTest extends FlatSpec with Matchers {
+import scala.util.{Failure, Success}
+import OpticsExamples._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class OpticsExamplesUnitTest extends AnyFlatSpec with Matchers {
 
   "OpticExamples" should "update stock without Lenses" in {
     val currentStock = 10

--- a/scala-libraries/src/test/scala/com/baeldung/scala/reactivemongo/ReactiveMongoUnitTest.scala
+++ b/scala-libraries/src/test/scala/com/baeldung/scala/reactivemongo/ReactiveMongoUnitTest.scala
@@ -4,12 +4,12 @@ import de.flapdoodle.embed.mongo.MongodStarter
 import de.flapdoodle.embed.mongo.config.{MongodConfig, Net}
 import de.flapdoodle.embed.mongo.distribution.Version
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AsyncWordSpec
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FutureOutcome}
 import MongoEntityImplicits._
 import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Sink
+import org.scalatest.wordspec.AsyncWordSpec
 import reactivemongo.api.Cursor
 import reactivemongo.api.bson.BSONDocument
 

--- a/scala-libraries/src/test/scala/com/baeldung/scala/scalaz/principles/ScalazPrinciplesExamplesUnitTest.scala
+++ b/scala-libraries/src/test/scala/com/baeldung/scala/scalaz/principles/ScalazPrinciplesExamplesUnitTest.scala
@@ -1,9 +1,9 @@
 package com.baeldung.scala.scalaz.principles
 
 import com.baeldung.scala.scalaz.principles.ScalazPrinciplesExamples._
-import org.scalatest._
+import org.scalatest.flatspec.AnyFlatSpec
 
-class ScalazPrinciplesExamplesUnitTest extends FlatSpec{
+class ScalazPrinciplesExamplesUnitTest extends AnyFlatSpec {
 
   it should "sort ints and strings" in {
     val integers = List(3, 2, 6, 5, 4, 1)

--- a/scala-libraries/src/test/scala/com/baeldung/scala/slick/PlayerServiceUnitTest.scala
+++ b/scala-libraries/src/test/scala/com/baeldung/scala/slick/PlayerServiceUnitTest.scala
@@ -2,11 +2,12 @@ package com.baeldung.scala.slick
 
 import java.sql.SQLException
 import java.time.LocalDate
-
 import com.baeldung.scala.slick.SlickTables.PlayerTable
 import org.scalactic.Equality
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{AsyncWordSpec, BeforeAndAfterAll, BeforeAndAfterEach, FutureOutcome, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, FutureOutcome}
 import slick.jdbc.H2Profile.api._
 
 import scala.concurrent.Future

--- a/scala-strings/src/test/scala/com/baeldung/scala/strings/camelcase/CamelCaseSpec.scala
+++ b/scala-strings/src/test/scala/com/baeldung/scala/strings/camelcase/CamelCaseSpec.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.strings.camelcase
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class CamelCaseSpec extends WordSpec {
+class CamelCaseSpec extends AnyWordSpec {
 
   import StringWrapper._
 

--- a/scala-strings/src/test/scala/com/baeldung/scala/strings/comparison/StringComparisonUnitTest.scala
+++ b/scala-strings/src/test/scala/com/baeldung/scala/strings/comparison/StringComparisonUnitTest.scala
@@ -1,8 +1,9 @@
 package com.baeldung.scala.strings.comparison
 
-import org.scalatest.{FeatureSpec, GivenWhenThen}
+import org.scalatest.GivenWhenThen
+import org.scalatest.featurespec.AnyFeatureSpec
 
-class StringComparisonUnitTest extends FeatureSpec with GivenWhenThen {
+class StringComparisonUnitTest extends AnyFeatureSpec with GivenWhenThen {
 
   scenario("String Comparison with ==, eq and equals") {
     

--- a/scala-strings/src/test/scala/com/baeldung/scala/strings/interpolation/strings/definition/UsingRegexUnitTest.scala
+++ b/scala-strings/src/test/scala/com/baeldung/scala/strings/interpolation/strings/definition/UsingRegexUnitTest.scala
@@ -1,10 +1,11 @@
 package com.baeldung.scala.strings.introduction
 
-import org.scalatest.{FeatureSpec, GivenWhenThen}
+import org.scalatest.GivenWhenThen
+import org.scalatest.featurespec.AnyFeatureSpec
 
 import scala.util.matching.Regex
 
-class UsingRegexUnitTest extends FeatureSpec with GivenWhenThen {
+class UsingRegexUnitTest extends AnyFeatureSpec with GivenWhenThen {
 
   scenario("Match with regular expression if a string contains letters and numbers") {
 

--- a/scala-strings/src/test/scala/com/baeldung/scala/strings/interpolation/strings/interpolation/CustomInterpolatorObjUnitTest.scala
+++ b/scala-strings/src/test/scala/com/baeldung/scala/strings/interpolation/strings/interpolation/CustomInterpolatorObjUnitTest.scala
@@ -1,9 +1,10 @@
 package com.baeldung.scala.strings.interpolation
 
-import org.scalatest.{FeatureSpec, GivenWhenThen}
 import com.baeldung.scala.strings.interpolation.CustomInterpolatorObj._
+import org.scalatest.GivenWhenThen
+import org.scalatest.featurespec.AnyFeatureSpec
 
-class CustomInterpolatorObjUnitTest extends FeatureSpec with GivenWhenThen {
+class CustomInterpolatorObjUnitTest extends AnyFeatureSpec with GivenWhenThen {
 
   scenario("The custom interpolator may work as expected") {
 

--- a/scala-test/src/test/scala/com/baeldung/scala/scalatest/ScalaMockFlatSpecUnitTest.scala
+++ b/scala-test/src/test/scala/com/baeldung/scala/scalatest/ScalaMockFlatSpecUnitTest.scala
@@ -1,7 +1,7 @@
 package com.baeldung.scala.scalatest
 
-import org.scalatest.flatspec.AnyFlatSpec
 import org.scalamock.scalatest.MockFactory
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 

--- a/scala-test/src/test/scala/com/baeldung/scala/scalatest/StringFlatSpecWithBeforeAndAfterUnitTest.scala
+++ b/scala-test/src/test/scala/com/baeldung/scala/scalatest/StringFlatSpecWithBeforeAndAfterUnitTest.scala
@@ -1,8 +1,7 @@
 package com.baeldung.scala.scalatest
 
-import org.scalatest.flatspec.AnyFlatSpec
-import collection.mutable.ListBuffer
 import org.scalatest.BeforeAndAfter
+import org.scalatest.flatspec.AnyFlatSpec
 
 class StringFlatSpecWithBeforeAndAfterUnitTest extends AnyFlatSpec with BeforeAndAfter {
 

--- a/scala-test/src/test/scala/com/baeldung/scala/scalatest/TaggedFlatSpecUnitTest.scala
+++ b/scala-test/src/test/scala/com/baeldung/scala/scalatest/TaggedFlatSpecUnitTest.scala
@@ -1,6 +1,6 @@
 package com.baeldung.scala.scalatest
 
-import org.scalatest.{Tag}
+import org.scalatest.Tag
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/scala-test/src/test/scala/com/baeldung/scala/scalatest/collectiontest/CollectionTest.scala
+++ b/scala-test/src/test/scala/com/baeldung/scala/scalatest/collectiontest/CollectionTest.scala
@@ -2,7 +2,7 @@ package com.baeldung.scala.scalatest.collectiontest
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.wordspec.AnyWordSpec
+
 import scala.util.Random
 
 class CollectionTest extends AnyFlatSpec with Matchers {

--- a/scala-test/src/test/scala/com/baeldung/scala/scalatest/collectiontest/Models.scala
+++ b/scala-test/src/test/scala/com/baeldung/scala/scalatest/collectiontest/Models.scala
@@ -1,5 +1,3 @@
 package com.baeldung.scala.scalatest.collectiontest
 
-import java.util.Objects
-
 case class Country(name:String, code:String)

--- a/scala-test/src/test/scala/com/baeldung/scala/scalatest/mockito/InventoryServiceTest.scala
+++ b/scala-test/src/test/scala/com/baeldung/scala/scalatest/mockito/InventoryServiceTest.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.scalatest.mockito
 
-import org.mockito.Mockito._
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec

--- a/scala-test/src/test/scala/com/baeldung/scala/scalatest/runner/ScalaTestRunnerTests.scala
+++ b/scala-test/src/test/scala/com/baeldung/scala/scalatest/runner/ScalaTestRunnerTests.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala.scalatest.runner
 
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.matchers.should.Matchers
 import org.scalatest.Tag
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 /**
   * This test class is a just a sample test to show scalatest Runner features.

--- a/scala212/src/test/scala/com/baeldung/scala/conversions/ConversionWrappersUnitTest.scala
+++ b/scala212/src/test/scala/com/baeldung/scala/conversions/ConversionWrappersUnitTest.scala
@@ -1,11 +1,11 @@
 package com.baeldung.scala.conversions
 
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import java.util.ArrayList
 
-class ConversionWrappersUnitTest extends FlatSpec with Matchers {
+class ConversionWrappersUnitTest extends AnyFlatSpec with Matchers {
 
   import scala.collection.JavaConverters._
 

--- a/scala212/src/test/scala/com/baeldung/scala/conversions/JavaToScalaConversionsUnitTest.scala
+++ b/scala212/src/test/scala/com/baeldung/scala/conversions/JavaToScalaConversionsUnitTest.scala
@@ -1,11 +1,11 @@
 package com.baeldung.scala.conversions
 
 import com.baedung.scala.conversions.JavaApi
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.convert.{DecorateAsJava, DecorateAsScala}
-import org.scalatest.FlatSpec
-import org.scalatest.matchers.should.Matchers
-class JavaToScalaConversionsUnitTest extends FlatSpec with Matchers
+class JavaToScalaConversionsUnitTest extends AnyFlatSpec with Matchers
   with DecorateAsScala with DecorateAsJava {
 
   "Standard conversions" should "convert from Java Iterators and back" in {

--- a/scala212/src/test/scala/com/baeldung/scala/conversions/ScalaToJavaConversionsUnitTest.scala
+++ b/scala212/src/test/scala/com/baeldung/scala/conversions/ScalaToJavaConversionsUnitTest.scala
@@ -1,10 +1,11 @@
 package com.baeldung.scala.conversions
 
 import com.baedung.scala.conversions.JavaApi
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.convert.DecorateAsJava
-class ScalaToJavaConversionsUnitTest extends FlatSpec with Matchers
+class ScalaToJavaConversionsUnitTest extends AnyFlatSpec with Matchers
   with DecorateAsJava {
 
   "A Scala Iterable" should "be passable as a parameter expecting a Java Collection" in {

--- a/scala212/src/test/scala/com/baeldung/scala/maps/MapsUnitTest.scala
+++ b/scala212/src/test/scala/com/baeldung/scala/maps/MapsUnitTest.scala
@@ -1,13 +1,13 @@
 package com.baeldung.scala.maps
 
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
 import java.util.concurrent.atomic.AtomicInteger
-
-import org.scalatest.{Matchers, WordSpec}
-
 import scala.collection.immutable.ListMap
 import scala.collection.{SortedMap, immutable, mutable}
 
-class MapsUnitTest extends WordSpec with Matchers {
+class MapsUnitTest extends AnyWordSpec with Matchers {
 
   "immutable.Map" should {
     val map: Map[Int, String] = immutable.Map((1, "first"), 2 -> "second")

--- a/scala3-lang-2/build.sbt
+++ b/scala3-lang-2/build.sbt
@@ -1,7 +1,3 @@
 val scala3Version = "3.2.0"
 
 scalaVersion := scala3Version
-
-libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.9" % Test
-)

--- a/scala3-lang/build.sbt
+++ b/scala3-lang/build.sbt
@@ -2,6 +2,3 @@ val scala3Version = "3.2.0"
 
 scalaVersion := scala3Version
 
-libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.9" % Test
-)

--- a/scala3-lang/src/main/scala/com/baeldung/scala3/implicits/ProvidingContextualEnvironment.scala
+++ b/scala3-lang/src/main/scala/com/baeldung/scala3/implicits/ProvidingContextualEnvironment.scala
@@ -1,6 +1,6 @@
 package com.baeldung.scala3.implicits
 
-import scala.concurrent.duration._
+import scala.concurrent.duration.*
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 object ProvidingContextualEnvironment {

--- a/scala3-lang/src/main/scala/com/baeldung/scala3/implicits/comparison/scala2/ImplicitlyMagic.scala
+++ b/scala3-lang/src/main/scala/com/baeldung/scala3/implicits/comparison/scala2/ImplicitlyMagic.scala
@@ -5,7 +5,7 @@ object PrinterProvider {
 }
 
 class ImplicitlyMagic {
-  import PrinterProvider._
+  import PrinterProvider.*
   def greet(msg: String): Unit = {
     val printer = implicitly[Printer]
     printer.write(msg)

--- a/scala3-lang/src/main/scala/com/baeldung/scala3/intersectiontypes/DuckTyping.scala
+++ b/scala3-lang/src/main/scala/com/baeldung/scala3/intersectiontypes/DuckTyping.scala
@@ -1,5 +1,5 @@
 package com.baeldung.scala3.intersectiontypes
-import reflect.Selectable.reflectiveSelectable
+import scala.reflect.Selectable.reflectiveSelectable
 
 object DuckTyping {
 

--- a/scala3-lang/src/main/scala/com/baeldung/scala3/macros/inline/InlineCompilerValidation.scala
+++ b/scala3-lang/src/main/scala/com/baeldung/scala3/macros/inline/InlineCompilerValidation.scala
@@ -1,7 +1,7 @@
 package com.baeldung.scala3.macros.inline
 
-import scala.util.Random
 import scala.compiletime.*
+import scala.util.Random
 
 object InlineCompilerError {
   inline def checkPort(portNo: Int) = {

--- a/scala3-lang/src/main/scala/com/baeldung/scala3/quitesyntax/Example.scala
+++ b/scala3-lang/src/main/scala/com/baeldung/scala3/quitesyntax/Example.scala
@@ -1,13 +1,8 @@
 package com.baeldung.scala3.quitesyntax
 
-import scala.collection.*                   // Scala 3
-import scala.collection._                   // Scala 2
-
-import scala.collection.mutable.Map as MMap   // Scala 3
-import scala.collection.mutable.{Map => MMap} // Scala 2
-
-import java.util.{Random as _, *}             // Scala 3
-import java.util.{Random => _, _}             // Scala 2
+import java.util.{Random as _, *}
+import scala.collection.*
+import scala.collection.mutable.Map as MMap             // Scala 2
 
 object Example {
 

--- a/scala3-lang/src/main/scala/com/baeldung/scala3/typesystem/OpaqueTypeAlias.scala
+++ b/scala3-lang/src/main/scala/com/baeldung/scala3/typesystem/OpaqueTypeAlias.scala
@@ -1,9 +1,9 @@
 package com.baeldung.scala3.typesystem
 
-import com.baeldung.scala3.typesystem.types._
-import scala.util.Try
+import com.baeldung.scala3.typesystem.types.*
 
 import java.time.LocalDate
+import scala.util.Try
 
 final case class Movie(name: String, year: Year, runningTime: RunningTimeInMin, noOfOscarsWon: NoOfOscarsWon)
 

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/ExtensionMethodUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/ExtensionMethodUnitTest.scala
@@ -1,6 +1,6 @@
 package com.baeldung.scala3.implicits
 
-import com.baeldung.scala3.implicits.ExtensionMethod._
+import com.baeldung.scala3.implicits.ExtensionMethod.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/ImplicitConversionUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/ImplicitConversionUnitTest.scala
@@ -1,6 +1,6 @@
 package com.baeldung.scala3.implicits
 
-import com.baeldung.scala3.implicits.ImplicitConversion._
+import com.baeldung.scala3.implicits.ImplicitConversion.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/ProvidingContextualEnvironmentUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/ProvidingContextualEnvironmentUnitTest.scala
@@ -1,13 +1,13 @@
 package com.baeldung.scala3.implicits
 
-import com.baeldung.scala3.implicits.ProvidingContextualEnvironment._
+import com.baeldung.scala3.implicits.ProvidingContextualEnvironment.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 import java.time.LocalDate
+import scala.concurrent.duration.*
 import scala.concurrent.{Await, ExecutionContext}
 import scala.language.implicitConversions
-import scala.concurrent.duration._
 class ProvidingContextualEnvironmentUnitTest extends AnyWordSpec with Matchers {
 
   "calling square function requiring execution context" should {

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/comparison/scala2/ExtensionUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/comparison/scala2/ExtensionUnitTest.scala
@@ -1,7 +1,7 @@
 package com.baeldung.scala3.implicits.comparison.scala2
-import org.scalatest.matchers.should.Matchers
+import com.baeldung.scala3.implicits.comparison.scala2.Extension.*
 import org.scalatest.flatspec.AnyFlatSpec
-import Extension._
+import org.scalatest.matchers.should.Matchers
 
 class ExtensionUnitTest extends AnyFlatSpec with Matchers {
 

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/comparison/scala2/ImplicitConversionUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/comparison/scala2/ImplicitConversionUnitTest.scala
@@ -1,8 +1,7 @@
 package com.baeldung.scala3.implicits.comparison.scala2
-import org.scalatest.matchers.should.Matchers
+import com.baeldung.scala3.implicits.comparison.scala2.ImplicitConversion.*
 import org.scalatest.flatspec.AnyFlatSpec
-
-import ImplicitConversion._
+import org.scalatest.matchers.should.Matchers
 
 class ImplicitConversionUnitTest extends AnyFlatSpec with Matchers {
   it should "use the implicit conversion" in {

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/comparison/scala2/ImplicitParameterUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/comparison/scala2/ImplicitParameterUnitTest.scala
@@ -1,6 +1,6 @@
 package com.baeldung.scala3.implicits.comparison.scala2
-import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class ImplicitParameterUnitTest extends AnyFlatSpec with Matchers {
   it should "use the implicit parameter" in {

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/comparison/scala3/ExtensionUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/comparison/scala3/ExtensionUnitTest.scala
@@ -1,18 +1,18 @@
 package com.baeldung.scala3.implicits.comparison.scala3
-import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class ExtensionUnitTest extends AnyFlatSpec with Matchers {
 
   it should "extend Int to create Second" in {
-    import Extension._
+    import Extension.*
     val sec: Second = 100.toSecond()
     val result = TimeUtil.doSomethingWithProcessingTime(sec)
     result shouldBe "100 seconds"
   }
 
   it should "extend a numeric using generic extension" in {
-    import NumericExtensions._
+    import NumericExtensions.*
     val addInts = 10.add(9)
     addInts shouldBe 19
     val addDoubles = 10d.add(0.2d)

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/comparison/scala3/ImplicitConversionUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/comparison/scala3/ImplicitConversionUnitTest.scala
@@ -1,9 +1,8 @@
 package com.baeldung.scala3.implicits.comparison.scala3
 
-import org.scalatest.matchers.should.Matchers
+import com.baeldung.scala3.implicits.comparison.scala3.ImplicitConversion.*
 import org.scalatest.flatspec.AnyFlatSpec
-
-import ImplicitConversion._
+import org.scalatest.matchers.should.Matchers
 
 class ImplicitConversionUnitTest extends AnyFlatSpec with Matchers {
   it should "use the implicit conversion" in {

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/comparison/scala3/ImplicitParameterUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/comparison/scala3/ImplicitParameterUnitTest.scala
@@ -1,7 +1,7 @@
 package com.baeldung.scala3.implicits.comparison.scala3
 
-import org.scalatest.matchers.should.Matchers
 import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class ImplicitParameterUnitTest extends AnyFlatSpec with Matchers {
   it should "use the implicit parameter" in {

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/extensions/ExtensionsUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/implicits/extensions/ExtensionsUnitTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.wordspec.AnyWordSpec
 class ExtensionsUnitTest extends AnyWordSpec with Matchers {
 
   "String Extensions" should {
-    import StringExtensions._
+    import StringExtensions.*
 
     "convert string to snake case" in {
       val str = "helloWorldScala3"
@@ -26,7 +26,7 @@ class ExtensionsUnitTest extends AnyWordSpec with Matchers {
   }
 
   "Generic Extensions" should {
-    import GenericExtensions._
+    import GenericExtensions.*
 
     "work for List[Int] for getSecond method" in {
       val intList = List(1, 2, 3, 4)

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/intersectiontypes/BasicIntersectionTypeUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/intersectiontypes/BasicIntersectionTypeUnitTest.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala3.intersectiontypes
 
+import com.baeldung.scala3.intersectiontypes.BasicIntersectionType.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import com.baeldung.scala3.intersectiontypes.BasicIntersectionType._
 
 class BasicIntersectionTypeUnitTest extends AnyWordSpec with Matchers {
 

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/intersectiontypes/DuckTypingUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/intersectiontypes/DuckTypingUnitTest.scala
@@ -1,9 +1,10 @@
 package com.baeldung.scala3.intersectiontypes
 
+import com.baeldung.scala3.intersectiontypes.DuckTyping.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import com.baeldung.scala3.intersectiontypes.DuckTyping._
-import reflect.Selectable.reflectiveSelectable
+
+import scala.reflect.Selectable.reflectiveSelectable
 
 class DuckTypingUnitTest extends AnyWordSpec with Matchers {
 

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/intersectiontypes/InheritanceUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/intersectiontypes/InheritanceUnitTest.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala3.intersectiontypes
 
+import com.baeldung.scala3.intersectiontypes.Inheritance.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import com.baeldung.scala3.intersectiontypes.Inheritance._
 
 class InheritanceUnitTest extends AnyWordSpec with Matchers {
 

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/intersectiontypes/OverloadingUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/intersectiontypes/OverloadingUnitTest.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala3.intersectiontypes
 
+import com.baeldung.scala3.intersectiontypes.Overloading.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import com.baeldung.scala3.intersectiontypes.Overloading._
 
 class OverloadingUnitTest extends AnyWordSpec with Matchers {
   "Overloading" should {

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/multiversalequality/CanEqualDeriveClauseUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/multiversalequality/CanEqualDeriveClauseUnitTest.scala
@@ -1,7 +1,7 @@
 package com.baeldung.scala3.multiversalequality
+import com.baeldung.scala3.multiversalequality.CanEqualDeriveClause.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import CanEqualDeriveClause.*
 
 class CanEqualDeriveClauseUnitTest extends AnyWordSpec with Matchers{
   "CanEqualDeriveClause equality check for different types deriving CanEqual TypeClass" should {

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/multiversalequality/CanEqualGivenInstanceUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/multiversalequality/CanEqualGivenInstanceUnitTest.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala3.multiversalequality
 
+import com.baeldung.scala3.multiversalequality.CanEqualGivenInstance.{email, letter}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import CanEqualGivenInstance.{email, letter}
 
 class CanEqualGivenInstanceUnitTest extends AnyWordSpec with Matchers{
   "CanEqualGivenInstance equality check for different types" should {

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/multiversalequality/MultiversalEqualityUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/multiversalequality/MultiversalEqualityUnitTest.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala3.multiversalequality
+import com.baeldung.scala3.multiversalequality.MultiversalEquality.{fido, rover}
 import com.baeldung.scala3.multiversalequality.UniversalEquality.Square
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import MultiversalEquality.{fido, rover}
 
 class MultiversalEqualityUnitTest extends AnyWordSpec with Matchers{
   "Multiversal equality check for different types" should {

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/multiversalequality/UniversalEqualityUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/multiversalequality/UniversalEqualityUnitTest.scala
@@ -1,7 +1,7 @@
 package com.baeldung.scala3.multiversalequality
+import com.baeldung.scala3.multiversalequality.UniversalEquality.{Circle, Square}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import UniversalEquality.{Square, Circle}
 
 class UniversalEqualityUnitTest extends AnyWordSpec with Matchers{
   "Universal equality check for different types" should {

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/traits/ParameterizedTraitUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/traits/ParameterizedTraitUnitTest.scala
@@ -1,6 +1,6 @@
 package com.baeldung.scala3.traits
 
-import com.baeldung.scala3.traits.ParameterizedTrait.{Foo, Base}
+import com.baeldung.scala3.traits.ParameterizedTrait.{Base, Foo}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/typesystem/CompoundTypesUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/typesystem/CompoundTypesUnitTest.scala
@@ -1,8 +1,8 @@
 package com.baeldung.scala3.typesystem
 
-import com.baeldung.scala3.typesystem.CompoundTypes.Union._
-import com.baeldung.scala3.typesystem.CompoundTypes.Intersection._
-import com.baeldung.scala3.typesystem.types._
+import com.baeldung.scala3.typesystem.CompoundTypes.Intersection.*
+import com.baeldung.scala3.typesystem.CompoundTypes.Union.*
+import com.baeldung.scala3.typesystem.types.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/scala3-lang/src/test/scala/com/baeldung/scala3/typesystem/OpaqueTypeAliasUnitTest.scala
+++ b/scala3-lang/src/test/scala/com/baeldung/scala3/typesystem/OpaqueTypeAliasUnitTest.scala
@@ -1,6 +1,6 @@
 package com.baeldung.scala3.typesystem
 
-import com.baeldung.scala3.typesystem.types._
+import com.baeldung.scala3.typesystem.types.*
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 

--- a/zio/src/main/scala/com/baeldung/scala/zio/SequentialEffectComposition.scala
+++ b/zio/src/main/scala/com/baeldung/scala/zio/SequentialEffectComposition.scala
@@ -1,7 +1,6 @@
 package com.baeldung.scala.zio
 
-import zio.ZIOAppDefault
-import zio.Console
+import zio.{Console, ZIOAppDefault}
 
 object SequentialEffectComposition extends ZIOAppDefault {
   def run =


### PR DESCRIPTION
## Changes
- Upgraded scalatest to latest version
- Added all the related dependncies since scalatest changed their library structures
- Upgraded all possible libraries to latest version where there are no conflicts or api changes
- Fixed all imports due to re-structuring of scalatest modules
- Also, created a single deps list for scalatest to be used across all sub modules to avoid future issues like this. It is better to always use same scalatest version across all submodules.

**Note: Updated almost all libraries to latest version where there is no code change is required. Some of the pending libraries which cause compilation errors are akka, fs2, skunk, embedded-mongo, logback**