### PR TITLE
Version Upgrades - JAVA-18572

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ val catsEffect = "org.typelevel" %% "cats-effect" % "3.4.7"
 val catEffectTest = "org.typelevel" %% "cats-effect-testkit" % "3.4.7" % Test
 val scalaReflection = "org.scala-lang" % "scala-reflect" % scalaV
 val logback = "ch.qos.logback" % "logback-classic" % "1.3.5"
+val embedMongoVersion = "3.5.4"
 
 val scalaTestDeps = Seq(
   "org.scalatest" %% "scalatest" % "3.2.15" % Test,
@@ -165,7 +166,7 @@ lazy val scala_akka_dependencies: Seq[ModuleID] = Seq(
   "org.mongodb.scala" %% "mongo-scala-driver" % "4.9.0",
   "com.lightbend.akka" %% "akka-stream-alpakka-file" % "5.0.0",
   jUnitInterface,
-  "de.flapdoodle.embed" % "de.flapdoodle.embed.mongo" % "2.2.0" % Test,
+  "de.flapdoodle.embed" % "de.flapdoodle.embed.mongo" % embedMongoVersion % Test,
   "com.typesafe.akka" %% "akka-http" % "10.4.0"
 ) ++ scalaTestDeps
 lazy val scala_test_junit4 = (project in file("scala-test-junit4"))
@@ -224,7 +225,7 @@ lazy val scala_libraries = (project in file("scala-libraries"))
       "junit" % "junit" % "4.13.2" % Test,
       "org.reactivemongo" %% "reactivemongo" % reactiveMongo,
       "org.reactivemongo" %% "reactivemongo-akkastream" % reactiveMongo,
-      "de.flapdoodle.embed" % "de.flapdoodle.embed.mongo" % "3.0.0" % Test,
+      "de.flapdoodle.embed" % "de.flapdoodle.embed.mongo" % embedMongoVersion % Test,
       logback % Test,
       "com.typesafe.akka" %% "akka-actor-typed" % AkkaVersion,
       "com.typesafe.akka" %% "akka-stream" % AkkaVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ val catsEffect = "org.typelevel" %% "cats-effect" % "3.4.7"
 val catEffectTest = "org.typelevel" %% "cats-effect-testkit" % "3.4.7" % Test
 val scalaReflection = "org.scala-lang" % "scala-reflect" % scalaV
 val logback = "ch.qos.logback" % "logback-classic" % "1.3.5"
-val embedMongoVersion = "3.5.4"
+val embedMongoVersion = "4.5.1"
 
 val scalaTestDeps = Seq(
   "org.scalatest" %% "scalatest" % "3.2.15" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -162,7 +162,7 @@ lazy val scala_akka_dependencies: Seq[ModuleID] = Seq(
   "com.typesafe.akka" %% "akka-actor-testkit-typed" % "2.7.0" % Test,
   "com.lightbend.akka" %% "akka-stream-alpakka-mongodb" % "5.0.0",
   "com.typesafe.akka" %% "akka-stream" % "2.7.0",
-  "org.mongodb.scala" %% "mongo-scala-driver" % "2.9.0",
+  "org.mongodb.scala" %% "mongo-scala-driver" % "4.9.0",
   "com.lightbend.akka" %% "akka-stream-alpakka-file" % "5.0.0",
   jUnitInterface,
   "de.flapdoodle.embed" % "de.flapdoodle.embed.mongo" % "2.2.0" % Test,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.5.8
+sbt.version=1.8.2
 

--- a/scala-akka/src/test/scala/com/baeldung/scala/akka/alpakka/AlpakkaIntegrationTest.scala
+++ b/scala-akka/src/test/scala/com/baeldung/scala/akka/alpakka/AlpakkaIntegrationTest.scala
@@ -4,10 +4,11 @@ import akka.stream.alpakka.file.scaladsl.FileTailSource
 import akka.stream.alpakka.mongodb.scaladsl.MongoSource
 import akka.stream.scaladsl.{Sink, Source}
 import com.typesafe.config.ConfigFactory
-import de.flapdoodle.embed.mongo.MongodStarter
-import de.flapdoodle.embed.mongo.config.{MongodConfig, Net}
+import de.flapdoodle.embed.mongo.config.Net
 import de.flapdoodle.embed.mongo.distribution.Version
+import de.flapdoodle.embed.mongo.transitions.{ImmutableMongod, Mongod}
 import de.flapdoodle.embed.process.runtime.Network
+import de.flapdoodle.reverse.transitions.Start
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
@@ -23,22 +24,14 @@ class AlpakkaIntegrationTest
   with ScalaFutures
   with BeforeAndAfterAll {
 
-  val starter = MongodStarter.getDefaultInstance
   val ip = ConfigFactory.load.getString("alpakka.mongo.connection.ip")
   val port = ConfigFactory.load.getInt("alpakka.mongo.connection.port")
-  val mongoDBConfig = MongodConfig
-    .builder()
-    .version(Version.Main.PRODUCTION)
-    .net(new Net(ip, port, Network.localhostIsIPv6()))
+  val mongodInstance: ImmutableMongod = Mongod.builder()
+    .net(Start.to(classOf[Net]).initializedWith(Net.of(ip, port, Network.localhostIsIPv6())))
     .build()
-  val mongod = starter.prepare(mongoDBConfig)
 
   override def beforeAll() = {
-    mongod.start()
-  }
-
-  override def afterAll() = {
-    mongod.stop()
+    mongodInstance.start(Version.Main.V4_4)
   }
 
   "Alpakka MongoDB integration service" must {

--- a/scala-akka/src/test/scala/com/baeldung/scala/akka/alpakka/AlpakkaIntegrationTest.scala
+++ b/scala-akka/src/test/scala/com/baeldung/scala/akka/alpakka/AlpakkaIntegrationTest.scala
@@ -5,7 +5,7 @@ import akka.stream.alpakka.mongodb.scaladsl.MongoSource
 import akka.stream.scaladsl.{Sink, Source}
 import com.typesafe.config.ConfigFactory
 import de.flapdoodle.embed.mongo.MongodStarter
-import de.flapdoodle.embed.mongo.config.{MongodConfigBuilder, Net}
+import de.flapdoodle.embed.mongo.config.{MongodConfig, Net}
 import de.flapdoodle.embed.mongo.distribution.Version
 import de.flapdoodle.embed.process.runtime.Network
 import org.scalatest.BeforeAndAfterAll
@@ -26,7 +26,8 @@ class AlpakkaIntegrationTest
   val starter = MongodStarter.getDefaultInstance
   val ip = ConfigFactory.load.getString("alpakka.mongo.connection.ip")
   val port = ConfigFactory.load.getInt("alpakka.mongo.connection.port")
-  val mongoDBConfig = new MongodConfigBuilder()
+  val mongoDBConfig = MongodConfig
+    .builder()
     .version(Version.Main.PRODUCTION)
     .net(new Net(ip, port, Network.localhostIsIPv6()))
     .build()


### PR DESCRIPTION
Updated libraries
- mongo-scala-driver : Major version update
- sbt version update
- flapdoodle embedded mongo

Only versions(flapdoodle and mongo-scala-driver) need to be updated in live, no code change needed:
- https://www.baeldung.com/scala/mongo-reactive-intro
- https://www.baeldung.com/scala/alpakka-intro