### PR TITLE
Scala 594 builder pattern

### DIFF
--- a/scala-core-8/src/main/scala-2/com/baeldung/scala/builderpattern/Guitar.scala
+++ b/scala-core-8/src/main/scala-2/com/baeldung/scala/builderpattern/Guitar.scala
@@ -1,7 +1,7 @@
 package com.baeldung.scala.builderpattern
 
 case class Guitar(
-  isElectric: Boolean = true,
+  isElectric: Boolean = false,
   numberOfStrings: Int = 6,
   tuning: String = "standard",
   tone: String = "clean",

--- a/scala-core-8/src/main/scala-2/com/baeldung/scala/builderpattern/Guitar.scala
+++ b/scala-core-8/src/main/scala-2/com/baeldung/scala/builderpattern/Guitar.scala
@@ -1,0 +1,14 @@
+package com.baeldung.scala.builderpattern
+
+case class Guitar(
+  isElectric: Boolean = true,
+  numberOfStrings: Int = 6,
+  tuning: String = "standard",
+  tone: String = "clean",
+  reverb: Float = 0.0f,
+  delay: Int = 0
+)
+
+object Guitar {
+  def builder(): GuitarBuilder = GuitarBuilder()
+}

--- a/scala-core-8/src/main/scala-2/com/baeldung/scala/builderpattern/GuitarBuilder.scala
+++ b/scala-core-8/src/main/scala-2/com/baeldung/scala/builderpattern/GuitarBuilder.scala
@@ -1,0 +1,33 @@
+package com.baeldung.scala.builderpattern
+
+case class GuitarBuilder(
+  isElectric: Boolean = true,
+  numberOfStrings: Int = 6,
+  tuning: String = "standard",
+  tone: String = "clean",
+  reverb: Float = 0.0f,
+  delay: Int = 0
+) {
+  def withElectric(isElectric: Boolean): GuitarBuilder =
+    copy(isElectric = isElectric)
+
+  def withNStrings(nStrings: Int): GuitarBuilder =
+    copy(numberOfStrings = nStrings)
+
+  def withTuning(tuning: String): GuitarBuilder = copy(tuning = tuning)
+
+  def withTone(tone: String): GuitarBuilder = copy(tone = tone)
+
+  def withReverb(reverb: Float): GuitarBuilder = copy(reverb = reverb)
+
+  def withDelay(delay: Int): GuitarBuilder = copy(delay = delay)
+
+  def build() = Guitar(
+    isElectric = isElectric,
+    numberOfStrings = numberOfStrings,
+    tuning = tuning,
+    tone = tone,
+    reverb = reverb,
+    delay = delay
+  )
+}

--- a/scala-core-8/src/main/scala-2/com/baeldung/scala/builderpattern/GuitarBuilder.scala
+++ b/scala-core-8/src/main/scala-2/com/baeldung/scala/builderpattern/GuitarBuilder.scala
@@ -22,7 +22,7 @@ case class GuitarBuilder(
 
   def withDelay(delay: Int): GuitarBuilder = copy(delay = delay)
 
-  def build() = Guitar(
+  def build(): Guitar = Guitar(
     isElectric = isElectric,
     numberOfStrings = numberOfStrings,
     tuning = tuning,

--- a/scala-core-8/src/main/scala-2/com/baeldung/scala/builderpattern/GuitarBuilder.scala
+++ b/scala-core-8/src/main/scala-2/com/baeldung/scala/builderpattern/GuitarBuilder.scala
@@ -1,7 +1,7 @@
 package com.baeldung.scala.builderpattern
 
-case class GuitarBuilder(
-  isElectric: Boolean = true,
+case class GuitarBuilder private (
+  isElectric: Boolean = false,
   numberOfStrings: Int = 6,
   tuning: String = "standard",
   tone: String = "clean",

--- a/scala-core-8/src/main/scala-2/com/baeldung/scala/builderpattern/SafeGuitarBuilder.scala
+++ b/scala-core-8/src/main/scala-2/com/baeldung/scala/builderpattern/SafeGuitarBuilder.scala
@@ -12,10 +12,10 @@ case class SafeGuitarBuilder[Electric <: TBoolean] private (
   reverb: Float = 0.0f,
   delay: Int = 0
 ) {
-  def electric: SafeGuitarBuilder[TTrue] =
-    copy[TTrue](isElectric = true)
-
-  def withReverb(reverb: Float)(implicit ev: Electric =:= TTrue): SafeGuitarBuilder[TTrue] =
+  def electric: SafeGuitarBuilder[TTrue] = copy[TTrue](isElectric = true)
+  def withReverb(reverb: Float)(implicit
+    ev: Electric =:= TTrue
+  ): SafeGuitarBuilder[TTrue] =
     copy[TTrue](reverb = reverb)
 
   def build(): Guitar = Guitar(

--- a/scala-core-8/src/main/scala-2/com/baeldung/scala/builderpattern/SafeGuitarBuilder.scala
+++ b/scala-core-8/src/main/scala-2/com/baeldung/scala/builderpattern/SafeGuitarBuilder.scala
@@ -1,0 +1,33 @@
+package com.baeldung.scala.builderpattern
+
+sealed trait TBoolean
+sealed trait TTrue extends TBoolean
+sealed trait TFalse extends TBoolean
+
+case class SafeGuitarBuilder[Electric <: TBoolean] private (
+  isElectric: Boolean = false,
+  numberOfStrings: Int = 6,
+  tuning: String = "standard",
+  tone: String = "clean",
+  reverb: Float = 0.0f,
+  delay: Int = 0
+) {
+  def electric: SafeGuitarBuilder[TTrue] = copy[TTrue](isElectric = true)
+
+  def withReverb(reverb: Float)(implicit
+    ev: Electric =:= TTrue
+  ): SafeGuitarBuilder[TTrue] = copy[TTrue](reverb = reverb)
+
+  def build(): Guitar = Guitar(
+    isElectric = isElectric,
+    numberOfStrings = numberOfStrings,
+    tuning = tuning,
+    tone = tone,
+    reverb = reverb,
+    delay = delay
+  )
+}
+
+object SafeGuitarBuilder {
+  def apply() = new SafeGuitarBuilder[TFalse]()
+}

--- a/scala-core-8/src/main/scala-2/com/baeldung/scala/builderpattern/SafeGuitarBuilder.scala
+++ b/scala-core-8/src/main/scala-2/com/baeldung/scala/builderpattern/SafeGuitarBuilder.scala
@@ -12,11 +12,11 @@ case class SafeGuitarBuilder[Electric <: TBoolean] private (
   reverb: Float = 0.0f,
   delay: Int = 0
 ) {
-  def electric: SafeGuitarBuilder[TTrue] = copy[TTrue](isElectric = true)
+  def electric: SafeGuitarBuilder[TTrue] =
+    copy[TTrue](isElectric = true)
 
-  def withReverb(reverb: Float)(implicit
-    ev: Electric =:= TTrue
-  ): SafeGuitarBuilder[TTrue] = copy[TTrue](reverb = reverb)
+  def withReverb(reverb: Float)(implicit ev: Electric =:= TTrue): SafeGuitarBuilder[TTrue] =
+    copy[TTrue](reverb = reverb)
 
   def build(): Guitar = Guitar(
     isElectric = isElectric,

--- a/scala-core-8/src/test/scala-2/com/baeldung/scala/builderpattern/GuitarSpec.scala
+++ b/scala-core-8/src/test/scala-2/com/baeldung/scala/builderpattern/GuitarSpec.scala
@@ -3,10 +3,11 @@ package com.baeldung.scala.builderpattern
 import org.scalatest.wordspec.AnyWordSpec
 
 class GuitarSpec extends AnyWordSpec {
-  "a guitar" should {
+
+  "an unsafe guitar builder" should {
     "resort to defaults when not initialised" in {
       val expectedGuitar = Guitar(
-        isElectric = true,
+        isElectric = false,
         numberOfStrings = 6,
         tuning = "standard",
         tone = "clean",
@@ -16,7 +17,7 @@ class GuitarSpec extends AnyWordSpec {
       val actualGuitar = GuitarBuilder().build()
       assertResult(expectedGuitar)(actualGuitar)
     }
-    "initialise only some values" in {
+    "initialise from just some values" in {
       val expectedGuitar = Guitar(
         isElectric = true,
         numberOfStrings = 6,
@@ -25,6 +26,7 @@ class GuitarSpec extends AnyWordSpec {
         reverb = 0.2f
       )
       val actualGuitar = GuitarBuilder()
+        .withElectric(true)
         .withTuning("dadgad")
         .withTone("brit-j800")
         .withReverb(0.2f)

--- a/scala-core-8/src/test/scala-2/com/baeldung/scala/builderpattern/GuitarSpec.scala
+++ b/scala-core-8/src/test/scala-2/com/baeldung/scala/builderpattern/GuitarSpec.scala
@@ -34,4 +34,18 @@ class GuitarSpec extends AnyWordSpec {
       assertResult(expectedGuitar)(actualGuitar)
     }
   }
+
+  "a safe guitar builder" should {
+    "allow reverb only in electric guitars" in {
+      assertTypeError("""
+          |val acousticGuitar = SafeGuitarBuilder()
+          |          .withReverb(0.2f)
+          |          .build()
+          |""".stripMargin)
+      val electricGuitar = SafeGuitarBuilder().electric
+        .withReverb(0.2f)
+        .build()
+    }
+  }
+
 }

--- a/scala-core-8/src/test/scala-2/com/baeldung/scala/builderpattern/GuitarSpec.scala
+++ b/scala-core-8/src/test/scala-2/com/baeldung/scala/builderpattern/GuitarSpec.scala
@@ -47,5 +47,4 @@ class GuitarSpec extends AnyWordSpec {
         .build()
     }
   }
-
 }

--- a/scala-core-8/src/test/scala-2/com/baeldung/scala/builderpattern/GuitarSpec.scala
+++ b/scala-core-8/src/test/scala-2/com/baeldung/scala/builderpattern/GuitarSpec.scala
@@ -1,0 +1,35 @@
+package com.baeldung.scala.builderpattern
+
+import org.scalatest.wordspec.AnyWordSpec
+
+class GuitarSpec extends AnyWordSpec {
+  "a guitar" should {
+    "resort to defaults when not initialised" in {
+      val expectedGuitar = Guitar(
+        isElectric = true,
+        numberOfStrings = 6,
+        tuning = "standard",
+        tone = "clean",
+        reverb = 0.0f,
+        delay = 0
+      )
+      val actualGuitar = GuitarBuilder().build()
+      assertResult(expectedGuitar)(actualGuitar)
+    }
+    "initialise only some values" in {
+      val expectedGuitar = Guitar(
+        isElectric = true,
+        numberOfStrings = 6,
+        tuning = "dadgad",
+        tone = "brit-j800",
+        reverb = 0.2f
+      )
+      val actualGuitar = GuitarBuilder()
+        .withTuning("dadgad")
+        .withTone("brit-j800")
+        .withReverb(0.2f)
+        .build()
+      assertResult(expectedGuitar)(actualGuitar)
+    }
+  }
+}


### PR DESCRIPTION
We explore a simple way to implement the builder pattern in Scala. In its simplest form it should be enough for vary many purposes. Then we extend the implementation to add type safety at compile time, by using type constraints.