### PR TITLE
SCALA-417: Demonstrate Java Duration to Scala FiniteDuration Conversion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,9 @@ lazy val scala_core_8 = (project in file("scala-core-8"))
     name := "scala-core-8",
     libraryDependencies += scalaReflection,
     libraryDependencies ++= scalaTestDeps,
-    libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value % "test"
+    libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value % "test",
+    libraryDependencies += "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.0",
+    libraryDependencies += "com.typesafe" % "config" % "1.2.0"
     // scalacOptions += "-Ymacro-debug-lite"
   )
 

--- a/scala-core-8/src/main/resources/application.conf
+++ b/scala-core-8/src/main/resources/application.conf
@@ -1,0 +1,3 @@
+timeout {
+    value = 60m
+}

--- a/scala-core-8/src/main/scala-2/com/baeldung/scala/duration/JavaToScalaDuration.scala
+++ b/scala-core-8/src/main/scala-2/com/baeldung/scala/duration/JavaToScalaDuration.scala
@@ -1,0 +1,20 @@
+package com.baeldung.scala.duration
+
+import com.typesafe.config.ConfigFactory
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.Duration
+
+object JavaToScalaDuration {
+
+  def asFiniteDuration(javaDuration: java.time.Duration) =
+    scala.concurrent.duration.Duration.fromNanos(javaDuration.toNanos)
+
+  def asFiniteDurationFromConf() = {
+    Duration.fromNanos(
+      ConfigFactory
+        .load()
+        .getDuration("timeout.value", TimeUnit.NANOSECONDS)
+    )
+  }
+}

--- a/scala-core-8/src/test/scala-2/com/baeldung/scala/duration/DurationTest.scala
+++ b/scala-core-8/src/test/scala-2/com/baeldung/scala/duration/DurationTest.scala
@@ -1,0 +1,44 @@
+package com.baeldung.scala.duration
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.{FiniteDuration, HOURS}
+import com.baeldung.scala.duration.JavaToScalaDuration.{
+  asFiniteDuration,
+  asFiniteDurationFromConf
+}
+
+import scala.jdk.DurationConverters.JavaDurationOps
+
+class DurationTest extends AnyFunSuite {
+
+  test("conversion from javaDuration using constructor") {
+    val javaDuration = Duration.of(1, ChronoUnit.HOURS)
+    val expected = scala.concurrent.duration.Duration(1, HOURS)
+    val actual = FiniteDuration.apply(javaDuration.toHours, TimeUnit.HOURS)
+    assert(expected == actual)
+  }
+
+  test("conversion from javaDuration using fromNanos") {
+    val javaDuration = Duration.of(1, ChronoUnit.HOURS)
+    val actual = asFiniteDuration(javaDuration)
+    val expected = scala.concurrent.duration.Duration(1, HOURS)
+    assert(expected == actual)
+  }
+
+  test("conversion from javaDuration using DurationConverter") {
+    val javaDuration = Duration.of(1, ChronoUnit.HOURS)
+    val actual = javaDuration.toScala
+    val expected = scala.concurrent.duration.Duration(1, HOURS)
+    assert(expected == actual)
+  }
+
+  test("reading duration from config file using typesafe") {
+    val actual = asFiniteDurationFromConf()
+    val expected = scala.concurrent.duration.Duration(1, TimeUnit.HOURS)
+    assert(expected == actual)
+  }
+}


### PR DESCRIPTION
## Summary
Demonstrate Java Duration to Scala FiniteDuration Conversion

## Jira
[SCALA-417](https://jira.baeldung.com/browse/SCALA-417)