### PR TITLE
[NO MERGE] Sample code and structure to showcase custom test configuration in SBT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,20 +33,26 @@ lazy val scala_core = (project in file("scala-core"))
   )
 
 lazy val scala_core_2 = (project in file("scala-core-2"))
+  .configs(ManualTests)
   .settings(
     name := "scala-core-2",
     libraryDependencies ++= scalaTestDeps,
     libraryDependencies += scalaMock,
-    libraryDependencies += jUnitInterface
+    libraryDependencies += jUnitInterface,
+    manualTestSettings
   )
 
+lazy val manualTestSettings = inConfig(ManualTests)(Defaults.testSettings)
+
 lazy val scala_core_3 = (project in file("scala-core-3"))
+  .configs(ManualTests)
   .settings(
     name := "scala-core-3",
     libraryDependencies ++= scalaTestDeps,
     libraryDependencies += jUnitInterface,
     libraryDependencies += scalaReflection,
-    libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "2.1.0"
+    libraryDependencies += "org.scala-lang.modules" %% "scala-xml" % "2.1.0",
+    manualTestSettings
   )
 
 lazy val scala_core_4 = (project in file("scala-core-4"))
@@ -343,7 +349,8 @@ lazy val scala_libraries_4 = (project in file("scala-libraries-4"))
     scalaVersion := "2.13.10",
     libraryDependencies += "com.lihaoyi" %% "utest" % "0.8.1" % "test",
     testFrameworks += new TestFramework("utest.runner.Framework"),
-    libraryDependencies ++= scalaTestDeps.map(_.withConfigurations(Some("it,test"))),
+    libraryDependencies ++= scalaTestDeps
+      .map(_.withConfigurations(Some("it,test"))),
     libraryDependencies ++= Seq(
       "org.scala-lang.modules" %% "scala-async" % "1.0.1",
       scalaReflection % Provided,
@@ -465,9 +472,11 @@ lazy val scala212 = (project in file("scala-2-modules/scala212"))
 
 addCommandAlias(
   "ci",
-  ";clean;compile;test:compile;it:compile;scalafmtCheckAll;test"
+  ";compile;test:compile;it:compile;scalafmtCheckAll;test"
 )
 addCommandAlias(
   "ciFull",
   ";ci;it:test"
 )
+
+lazy val ManualTests = config("manual") extend (Test)

--- a/scala-akka/src/test/scala-2/com/baeldung/scala/akka/scheduler/SchedulerUnitTest.scala
+++ b/scala-akka/src/test/scala-2/com/baeldung/scala/akka/scheduler/SchedulerUnitTest.scala
@@ -58,7 +58,10 @@ class SchedulerUnitTest
         "running the test: execute the task exactly once using Runnable interface"
       )
       val greeter =
-        system.actorOf(Props(classOf[Greetings]), "Greeter-With-Runnable")
+        system.actorOf(
+          Props(classOf[Greetings]),
+          "Greeter-With-Runnable-" + System.currentTimeMillis()
+        )
       val greet = Greet("Detective", "Lucifer")
       system.scheduler.scheduleOnce(
         500.millis,
@@ -76,7 +79,10 @@ class SchedulerUnitTest
 
     "execute a task periodically" in {
       val greeter =
-        system.actorOf(Props(classOf[Greetings]), "Periodic-Greeter")
+        system.actorOf(
+          Props(classOf[Greetings]),
+          "Periodic-Greeter-" + System.currentTimeMillis()
+        )
       val greet = Greet("Detective", "Lucifer")
       system.scheduler.schedule(10.millis, 250.millis, greeter, greet)
 
@@ -95,7 +101,7 @@ class SchedulerUnitTest
       val greeter =
         system.actorOf(
           Props(classOf[Greetings]),
-          "Periodic-Greeter-Fixed-Delay"
+          "Periodic-Greeter-Fixed-Delay-" + System.currentTimeMillis()
         )
       val greet = Greet("Detective", "Lucifer")
       system.scheduler.scheduleWithFixedDelay(
@@ -118,7 +124,10 @@ class SchedulerUnitTest
         "running the test: execute a task periodically using Runnable interface"
       )
       val greeter =
-        system.actorOf(Props(classOf[Greetings]), "Periodic-Greeter-Runnable")
+        system.actorOf(
+          Props(classOf[Greetings]),
+          "Periodic-Greeter-Runnable-" + System.currentTimeMillis()
+        )
       val greet = Greet("Detective", "Lucifer")
       system.scheduler.schedule(
         10.millis,
@@ -140,7 +149,10 @@ class SchedulerUnitTest
 
     "cancel a running scheduler" in {
       val greeter =
-        system.actorOf(Props(classOf[Greetings]), "Cancelling-Greeter")
+        system.actorOf(
+          Props(classOf[Greetings]),
+          "Cancelling-Greeter-" + System.currentTimeMillis()
+        )
       val greet = Greet("Detective", "Lucifer MorningStar")
       val schedulerInstance =
         system.scheduler.schedule(10.millis, 1.seconds, greeter, greet)
@@ -159,7 +171,10 @@ class SchedulerUnitTest
         "running the test: scheduleAtFixedRate should run the next execution at fixed rate even if the previous task took more time"
       )
       val greeter =
-        system.actorOf(Props(classOf[Greetings]), "Fixed-Rate-Scheduling")
+        system.actorOf(
+          Props(classOf[Greetings]),
+          "Fixed-Rate-Scheduling-" + System.currentTimeMillis()
+        )
       val greet = Greet("Detective", "Lucifer")
       var flag = true
       system.scheduler.scheduleAtFixedRate(10.millis, 500.millis)(new Runnable {

--- a/scala-core-2/src/manual/scala-2/com/baeldung/scala/ManualTestSample.scala
+++ b/scala-core-2/src/manual/scala-2/com/baeldung/scala/ManualTestSample.scala
@@ -1,0 +1,14 @@
+package com.baeldung.scala
+
+import org.scalatest.wordspec.AnyWordSpec
+
+class ManualTestSample extends AnyWordSpec {
+
+  "Manual test" should {
+    "run only with custom test configuration/profile" in {
+      println("++ Manual test started executing.....")
+      fail
+    }
+  }
+
+}

--- a/scala-core-3/src/manual/scala-2/com/baeldung/scala/ManualTestAnotherSample.scala
+++ b/scala-core-3/src/manual/scala-2/com/baeldung/scala/ManualTestAnotherSample.scala
@@ -1,0 +1,14 @@
+package com.baeldung.scala
+
+import org.scalatest.wordspec.AnyWordSpec
+
+class ManualTestAnotherSample extends AnyWordSpec {
+
+  "Shared SBT Config Manual test" should {
+    "run only with custom test configuration/profile using the shared settings" in {
+      println("++ Another Manual test started executing.....")
+      fail
+    }
+  }
+
+}


### PR DESCRIPTION
## Summary
This is a PR created to show how to use custom SBT test configuration. Additionally, fixed actor test during retries(Added timestamp to make actorname unique during retries)

## Description
SBT let's us create our own custom test configuration/profile, similar to the built-in `test`, `it` configs.
In this PR, I added a config as `manual`. With this, we can execute `Manul/compile` or `Manual/test` to perform similar operations. 
In this profile, the code should be under the directory `src/manual/scala` instead of `src/test/scala`

## UAT
- The PR build should pass as the `manual` scope is not included by default in PR builds
- If we execute the tests using `Manual/test`, there should be 2 test failures, as both the tests are made to fail

