### PR TITLE
Docker test fixes

### DIFF
--- a/scala-libraries-4/src/it/resources/s3-test.txt
+++ b/scala-libraries-4/src/it/resources/s3-test.txt
@@ -1,0 +1,1 @@
+dummy test file for docker tests

--- a/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/DockerComposeTest.scala
+++ b/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/DockerComposeTest.scala
@@ -1,14 +1,10 @@
 package com.baeldung.scala.testcontainers
 
-import com.dimafeng.testcontainers.{DockerComposeContainer, ExposedService}
 import com.dimafeng.testcontainers.scalatest.TestContainerForEach
-import org.scalatest.Ignore
+import com.dimafeng.testcontainers.{DockerComposeContainer, ExposedService}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.testcontainers.containers.wait.strategy.{
-  LogMessageWaitStrategy,
-  Wait
-}
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy
 import software.amazon.awssdk.auth.credentials.{
   AwsBasicCredentials,
   StaticCredentialsProvider
@@ -23,13 +19,19 @@ import software.amazon.awssdk.services.s3.model.{
 
 import java.io.File
 import java.net.URI
-import java.nio.file.Paths
 import scala.util.{Random, Try}
 
+/** use sbt command to run the test for e.g.: sbt "it:testOnly
+  * *LocalstackModuleTest" To run in IntelliJ IDEA, you need to either set the
+  * working directory to the sub-module for the test. Otherwise, the path to the
+  * file will not be correct. Another option is to temporarily change the file
+  * path as below (by prefixing with the sub-module name)
+  * scala-libraries-4/src/it/resources/s3-test.txt
+  */
 class DockerComposeTest
   extends AnyFlatSpec
-    with Matchers
-    with TestContainerForEach {
+  with Matchers
+  with TestContainerForEach {
 
   private val BucketName = Random.alphanumeric.take(10).mkString.toLowerCase
   private val ExposedPort = 5000
@@ -74,12 +76,16 @@ class DockerComposeTest
 
     Try(
       s3.headObject(
-        HeadObjectRequest.builder().bucket(BucketName).key(uploadFile.getName).build()
+        HeadObjectRequest
+          .builder()
+          .bucket(BucketName)
+          .key(uploadFile.getName)
+          .build()
       )
     ).fold(
       {
-        case ex: NoSuchKeyException => fail("File not found: "+ex)
-        case _                     => fail
+        case ex: NoSuchKeyException => fail("File not found: " + ex)
+        case _                      => fail
       },
       _ => succeed
     )

--- a/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/DockerComposeTest.scala
+++ b/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/DockerComposeTest.scala
@@ -22,11 +22,9 @@ import java.net.URI
 import scala.util.{Random, Try}
 
 /** use sbt command to run the test for e.g.: sbt "it:testOnly
-  * *LocalstackModuleTest" To run in IntelliJ IDEA, you need to either set the
-  * working directory to the sub-module for the test. Otherwise, the path to the
-  * file will not be correct. Another option is to temporarily change the file
-  * path as below (by prefixing with the sub-module name)
-  * scala-libraries-4/src/it/resources/s3-test.txt
+  * *DockerComposeTest". When you run in IntelliJ IDEA and if you get error
+  * regarding the resources, then mark the src/it/resources directory as "test
+  * resources" in intellij.
   */
 class DockerComposeTest
   extends AnyFlatSpec
@@ -35,11 +33,15 @@ class DockerComposeTest
 
   private val BucketName = Random.alphanumeric.take(10).mkString.toLowerCase
   private val ExposedPort = 5000
-  private val uploadFile = new File("src/it/resources/s3-test.txt")
+  private val uploadFile = new File(
+    getClass.getClassLoader.getResource("s3-test.txt").getFile
+  )
 
-  override val containerDef: DockerComposeContainer.Def =
+  override lazy val containerDef: DockerComposeContainer.Def = {
     DockerComposeContainer.Def(
-      new File("src/it/resources/docker-compose.yml"),
+      new File(
+        this.getClass.getClassLoader.getResource("docker-compose.yml").getFile
+      ),
       exposedServices = Seq(
         ExposedService(
           "localstack",
@@ -48,6 +50,7 @@ class DockerComposeTest
         )
       )
     )
+  }
 
   "SimpleS3Uploader" should "upload a file in the desired bucket" in {
     val region = "us-east-1"

--- a/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/GenericContainerTest.scala
+++ b/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/GenericContainerTest.scala
@@ -53,12 +53,10 @@ object MyLocalStackContainer {
 }
 
 /** use sbt command to run the test for e.g.: sbt "it:testOnly
-  * *LocalstackModuleTest" To run in IntelliJ IDEA, you need to either set the
-  * working directory to the sub-module for the test. Otherwise, the path to the
-  * file will not be correct. Another option is to temporarily change the file
-  * path as below (by prefixing with the sub-module name)
-  * scala-libraries-4/src/it/resources/s3-test.txt
-  */
+ * *GenericContainerTest". When you run in IntelliJ IDEA and if you get error
+ * regarding the resources, then mark the src/it/resources directory as "test
+ * resources" in intellij.
+ */
 class GenericContainerTest
   extends AnyFlatSpec
   with Matchers
@@ -92,7 +90,7 @@ class GenericContainerTest
         endpoint = new URI(ls.endpoint),
         accessKeyId = ls.accessKeyId,
         secretAccessKey = ls.secretAccessKey
-      ).upload(BucketName, Paths.get("src/it/resources/s3-test.txt"))
+      ).upload(BucketName, Paths.get(getClass.getClassLoader.getResource("s3-test.txt").toURI))
 
       Try(
         s3.headObject(

--- a/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/GenericContainerTest.scala
+++ b/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/GenericContainerTest.scala
@@ -85,14 +85,14 @@ class GenericContainerTest
         endpoint = new URI(ls.endpoint),
         accessKeyId = ls.accessKeyId,
         secretAccessKey = ls.secretAccessKey
-      ).upload(BucketName, Paths.get("build.sbt"))
+      ).upload(BucketName, Paths.get("src/it/resources/s3-test.txt"))
 
       Try(
         s3.headObject(
           HeadObjectRequest
             .builder()
             .bucket(BucketName)
-            .key("build.sbt")
+            .key("s3-test.txt")
             .build()
         )
       ).fold(

--- a/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/GenericContainerTest.scala
+++ b/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/GenericContainerTest.scala
@@ -52,6 +52,13 @@ object MyLocalStackContainer {
     )
 }
 
+/** use sbt command to run the test for e.g.: sbt "it:testOnly
+  * *LocalstackModuleTest" To run in IntelliJ IDEA, you need to either set the
+  * working directory to the sub-module for the test. Otherwise, the path to the
+  * file will not be correct. Another option is to temporarily change the file
+  * path as below (by prefixing with the sub-module name)
+  * scala-libraries-4/src/it/resources/s3-test.txt
+  */
 class GenericContainerTest
   extends AnyFlatSpec
   with Matchers

--- a/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/GenericContainerTest.scala
+++ b/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/GenericContainerTest.scala
@@ -53,10 +53,10 @@ object MyLocalStackContainer {
 }
 
 /** use sbt command to run the test for e.g.: sbt "it:testOnly
- * *GenericContainerTest". When you run in IntelliJ IDEA and if you get error
- * regarding the resources, then mark the src/it/resources directory as "test
- * resources" in intellij.
- */
+  * *GenericContainerTest". When you run in IntelliJ IDEA and if you get error
+  * regarding the resources, then mark the src/it/resources directory as "test
+  * resources" in intellij.
+  */
 class GenericContainerTest
   extends AnyFlatSpec
   with Matchers
@@ -90,7 +90,10 @@ class GenericContainerTest
         endpoint = new URI(ls.endpoint),
         accessKeyId = ls.accessKeyId,
         secretAccessKey = ls.secretAccessKey
-      ).upload(BucketName, Paths.get(getClass.getClassLoader.getResource("s3-test.txt").toURI))
+      ).upload(
+        BucketName,
+        Paths.get(getClass.getClassLoader.getResource("s3-test.txt").toURI)
+      )
 
       Try(
         s3.headObject(

--- a/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/LocalstackModuleTest.scala
+++ b/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/LocalstackModuleTest.scala
@@ -45,14 +45,14 @@ class LocalstackModuleTest
         endpoint = ls.endpointOverride(Service.S3),
         accessKeyId = ls.container.getAccessKey,
         secretAccessKey = ls.container.getSecretKey
-      ).upload(BucketName, Paths.get("build.sbt"))
+      ).upload(BucketName, Paths.get("src/it/resources/s3-test.txt"))
 
       Try(
         s3.headObject(
           HeadObjectRequest
             .builder()
             .bucket(BucketName)
-            .key("build.sbt")
+            .key("s3-test.txt")
             .build()
         )
       ).fold(

--- a/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/LocalstackModuleTest.scala
+++ b/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/LocalstackModuleTest.scala
@@ -16,10 +16,10 @@ import java.nio.file.Paths
 import scala.util.{Random, Try}
 
 /** use sbt command to run the test for e.g.: sbt "it:testOnly
- * *LocalstackModuleTest". When you run in IntelliJ IDEA and if you get error
- * regarding the resources, then mark the src/it/resources directory as "test
- * resources" in intellij.
- */
+  * *LocalstackModuleTest". When you run in IntelliJ IDEA and if you get error
+  * regarding the resources, then mark the src/it/resources directory as "test
+  * resources" in intellij.
+  */
 class LocalstackModuleTest
   extends AnyFlatSpec
   with Matchers
@@ -50,7 +50,10 @@ class LocalstackModuleTest
         endpoint = ls.endpointOverride(Service.S3),
         accessKeyId = ls.container.getAccessKey,
         secretAccessKey = ls.container.getSecretKey
-      ).upload(BucketName, Paths.get(getClass.getClassLoader.getResource("s3-test.txt").toURI))
+      ).upload(
+        BucketName,
+        Paths.get(getClass.getClassLoader.getResource("s3-test.txt").toURI)
+      )
 
       Try(
         s3.headObject(

--- a/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/LocalstackModuleTest.scala
+++ b/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/LocalstackModuleTest.scala
@@ -15,6 +15,13 @@ import software.amazon.awssdk.services.s3.model.{
 import java.nio.file.Paths
 import scala.util.{Random, Try}
 
+/** use sbt command to run the test for e.g.: sbt "it:testOnly
+  * *LocalstackModuleTest" To run in IntelliJ IDEA, you need to either set the
+  * working directory to the sub-module for the test. Otherwise, the path to the
+  * file will not be correct. Another option is to temporarily change the file
+  * path as below (by prefixing with the sub-module name)
+  * scala-libraries-4/src/it/resources/s3-test.txt
+  */
 class LocalstackModuleTest
   extends AnyFlatSpec
   with Matchers

--- a/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/LocalstackModuleTest.scala
+++ b/scala-libraries-4/src/it/scala-2/com/baeldung/scala/testcontainers/LocalstackModuleTest.scala
@@ -16,12 +16,10 @@ import java.nio.file.Paths
 import scala.util.{Random, Try}
 
 /** use sbt command to run the test for e.g.: sbt "it:testOnly
-  * *LocalstackModuleTest" To run in IntelliJ IDEA, you need to either set the
-  * working directory to the sub-module for the test. Otherwise, the path to the
-  * file will not be correct. Another option is to temporarily change the file
-  * path as below (by prefixing with the sub-module name)
-  * scala-libraries-4/src/it/resources/s3-test.txt
-  */
+ * *LocalstackModuleTest". When you run in IntelliJ IDEA and if you get error
+ * regarding the resources, then mark the src/it/resources directory as "test
+ * resources" in intellij.
+ */
 class LocalstackModuleTest
   extends AnyFlatSpec
   with Matchers
@@ -52,7 +50,7 @@ class LocalstackModuleTest
         endpoint = ls.endpointOverride(Service.S3),
         accessKeyId = ls.container.getAccessKey,
         secretAccessKey = ls.container.getSecretKey
-      ).upload(BucketName, Paths.get("src/it/resources/s3-test.txt"))
+      ).upload(BucketName, Paths.get(getClass.getClassLoader.getResource("s3-test.txt").toURI))
 
       Try(
         s3.headObject(


### PR DESCRIPTION
Fixed the tests related to docker:

- Adjusted the file path to execute correctly in sbt
- In IntelliJ, it was taking the project root as the base directory, but in sbt it uses the sub-module as the base directory.

## UAT
**Prerequisite: The environment should have docker installed and running for running the below test**
- To verify the tests, switch to this branch and execute the command `sbt "it:testOnly com.baeldung.scala.testcontainers.*"`
- This should run 3 tests and all of them should pass