### PR TITLE
Scala 597 find first match

### DIFF
--- a/scala-core-collections-2/src/main/scala-2/com/baeldung/scala/firstmatching/Finder.scala
+++ b/scala-core-collections-2/src/main/scala-2/com/baeldung/scala/firstmatching/Finder.scala
@@ -1,9 +1,14 @@
 package com.baeldung.scala.firstmatching
 
+import scala.annotation.tailrec
+
 object Finder {
   implicit class Wrapper[T](val sequence: Seq[T]) extends AnyVal {
-    def findMatch(condition: T => Boolean): Option[T] = {
-      sequence.find(condition)
+    @tailrec
+    final def findMatch(condition: T => Boolean): Option[T] = {
+      if (sequence.isEmpty) None
+      else if (condition(sequence.head)) Some(sequence.head)
+      else sequence.tail.findMatch(condition)
     }
   }
 }

--- a/scala-core-collections-2/src/main/scala-2/com/baeldung/scala/firstmatching/Finder.scala
+++ b/scala-core-collections-2/src/main/scala-2/com/baeldung/scala/firstmatching/Finder.scala
@@ -1,0 +1,9 @@
+package com.baeldung.scala.firstmatching
+
+object Finder {
+  implicit class Wrapper[T](val sequence: Seq[T]) extends AnyVal {
+    def findMatch(condition: T => Boolean): Option[T] = {
+      sequence.find(condition)
+    }
+  }
+}

--- a/scala-core-collections-2/src/test/scala-2/com/baeldung/scala/firstmatching/FinderSpec.scala
+++ b/scala-core-collections-2/src/test/scala-2/com/baeldung/scala/firstmatching/FinderSpec.scala
@@ -1,0 +1,29 @@
+package com.baeldung.scala.firstmatching
+
+import org.scalatest.wordspec.AnyWordSpec
+
+class FinderSpec extends AnyWordSpec {
+  import Finder._
+
+  "A finder" should {
+    "find nothing in an empty collection" in {
+      val collection = Vector[Int]()
+      val expected = None
+      val actual = collection.findMatch(_ > 0)
+      assertResult(expected)(actual)
+    }
+    "find nothing if the element is not there" in {
+      val collection = 2 :: 4 :: 6 :: 8 :: Nil
+      val expected = None
+      val actual = collection.findMatch(_ > 8)
+      assertResult(expected)(actual)
+    }
+    "find the first element that matches" in {
+      val collection =
+        ('a' -> 0) :: ('b' -> 1) :: ('c' -> 2) :: ('d' -> 3) :: Nil
+      val expected = 'b'
+      val actual = collection.findMatch(pair => pair._2 > 0)
+      assertResult(expected)(actual)
+    }
+  }
+}

--- a/scala-core-collections-2/src/test/scala-2/com/baeldung/scala/firstmatching/FinderSpec.scala
+++ b/scala-core-collections-2/src/test/scala-2/com/baeldung/scala/firstmatching/FinderSpec.scala
@@ -22,7 +22,7 @@ class FinderSpec extends AnyWordSpec {
       val collection =
         ('a' -> 0) :: ('b' -> 1) :: ('c' -> 2) :: ('d' -> 3) :: Nil
       val expected = 'b'
-      val actual = collection.findMatch(pair => pair._2 > 0)
+      val actual = collection.findMatch(pair => pair._2 > 0).get._1
       assertResult(expected)(actual)
     }
   }


### PR DESCRIPTION
This code accompanies article https://drafts.baeldung.com/scala/wp-admin/post.php?post=54811&action=edit about how to find the first element of a collection that satisfies a certain condition.