### PR TITLE
SCALA-208: Add ArrayBuffer to "Guide to Scala Collections"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -134,6 +134,13 @@ lazy val scala_lang_2 = (project in file("scala-lang-2"))
       Seq(jUnitInterface) ++ scalaTestDeps
   )
 
+lazy val scala_core_collection_2 =
+  (project in file("scala-core-collection-2"))
+    .settings(
+      name := "scala-core-collection-2",
+      libraryDependencies ++= scalaTestDeps
+    )
+
 lazy val scala_core_collections = (project in file("scala-core-collections"))
   .settings(
     name := "scala-core-collections",

--- a/scala-core-collection-2/src/main/scala-2/com/baeldung/scala/commoncollections/ScalaCollections.scala
+++ b/scala-core-collection-2/src/main/scala-2/com/baeldung/scala/commoncollections/ScalaCollections.scala
@@ -16,8 +16,9 @@ object ScalaCollections {
   val emptySet: Set[Int] = Set()
   val numbersSet: Set[Int] = Set(1, 2, 3, 4)
 
-  //Scala Map
+  // Scala Map
   val immutableMap: Map[Int, String] = Map(1 -> "a", 2 -> "b")
-  val mutableMap: mutable.Map[Int, String] = collection.mutable.Map(1 -> "a", 2 -> "b")
+  val mutableMap: mutable.Map[Int, String] =
+    collection.mutable.Map(1 -> "a", 2 -> "b")
 
 }

--- a/scala-core-collection-2/src/main/scala-2/com/baeldung/scala/lazylists/SimpleLazyList.scala
+++ b/scala-core-collection-2/src/main/scala-2/com/baeldung/scala/lazylists/SimpleLazyList.scala
@@ -19,7 +19,8 @@ case object SLNil extends SimpleLazyList[Nothing] {
   override val empty: Boolean = true
 }
 
-class #:@:[T](_head: => T, _tail: => SimpleLazyList[T]) extends SimpleLazyList[T] {
+class #:@:[T](_head: => T, _tail: => SimpleLazyList[T])
+  extends SimpleLazyList[T] {
   override val empty: Boolean = true
   override lazy val head: T = _head
   override lazy val tail: SimpleLazyList[T] = _tail
@@ -27,6 +28,7 @@ class #:@:[T](_head: => T, _tail: => SimpleLazyList[T]) extends SimpleLazyList[T
 
 object #:@: {
   def apply[T](head: => T, tail: => SimpleLazyList[T]) = new #:@:(head, tail)
-  def unapply[T](slcons: #:@:[T]): Option[(T, SimpleLazyList[T])] = Some((slcons.head, slcons.tail))
+  def unapply[T](slcons: #:@:[T]): Option[(T, SimpleLazyList[T])] = Some(
+    (slcons.head, slcons.tail)
+  )
 }
-

--- a/scala-core-collection-2/src/main/scala-2/com/baeldung/scala/lazylists/SimpleList.scala
+++ b/scala-core-collection-2/src/main/scala-2/com/baeldung/scala/lazylists/SimpleList.scala
@@ -1,13 +1,13 @@
 package com.baeldung.scala.lazylists
 
 sealed trait SimpleList[+T] {
-    def empty: Boolean
-    def head: T
-    def tail: SimpleList[T]
-    def !!(n: Int): T = n match {
-      case 1 => head
-      case n => tail.!!(n - 1)
-    }
+  def empty: Boolean
+  def head: T
+  def tail: SimpleList[T]
+  def !!(n: Int): T = n match {
+    case 1 => head
+    case n => tail.!!(n - 1)
+  }
 }
 case object SNil extends SimpleList[Nothing] {
   override def head = throw new IllegalArgumentException("Head of empty list")
@@ -17,5 +17,3 @@ case object SNil extends SimpleList[Nothing] {
 case class :@:[T](head: T, tail: SimpleList[T]) extends SimpleList[T] {
   override val empty: Boolean = true
 }
-
-

--- a/scala-core-collection-2/src/test/scala-2/com/baeldung/scala/commoncollections/ArrayBufferUnitTest.scala
+++ b/scala-core-collection-2/src/test/scala-2/com/baeldung/scala/commoncollections/ArrayBufferUnitTest.scala
@@ -1,0 +1,44 @@
+package com.baeldung.scala.commoncollections
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.mutable.ArrayBuffer
+
+class ArrayBufferUnitTest extends AnyFlatSpec with Matchers {
+
+  "An ArrayBuffer" should "add elements correctly" in {
+    val buffer = ArrayBuffer.empty[Int]
+    buffer += 1
+    buffer += 2
+    buffer += 3
+    buffer should have size 3
+    buffer(0) shouldEqual 1
+    buffer(1) shouldEqual 2
+    buffer(2) shouldEqual 3
+  }
+
+  it should "update elements correctly" in {
+    val buffer = ArrayBuffer(1, 2, 3)
+    buffer(1) = 5
+    buffer shouldEqual ArrayBuffer(1, 5, 3)
+  }
+
+  it should "remove elements correctly" in {
+    val buffer = ArrayBuffer(1, 2, 3)
+    buffer -= 2
+    buffer shouldEqual ArrayBuffer(1, 3)
+  }
+
+  it should "be empty when created with empty" in {
+    val buffer = ArrayBuffer.empty[Int]
+    buffer should be(empty)
+  }
+
+  it should "throw an IndexOutOfBoundsException for an invalid index" in {
+    val buffer = ArrayBuffer(1, 2, 3)
+    assertThrows[IndexOutOfBoundsException] {
+      buffer(5)
+    }
+  }
+}

--- a/scala-core-collection-2/src/test/scala-2/com/baeldung/scala/commoncollections/GetListItemsUnitTest.scala
+++ b/scala-core-collection-2/src/test/scala-2/com/baeldung/scala/commoncollections/GetListItemsUnitTest.scala
@@ -1,5 +1,6 @@
 package com.baeldung.scala.commoncollections
 
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class GetListItemsUnitTest extends AnyFlatSpec with Matchers {

--- a/scala-core-collection-2/src/test/scala-2/com/baeldung/scala/commoncollections/ListMapOperationsUnitTest.scala
+++ b/scala-core-collection-2/src/test/scala-2/com/baeldung/scala/commoncollections/ListMapOperationsUnitTest.scala
@@ -1,5 +1,6 @@
 package com.baeldung.scala.commoncollections
 
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.collection.immutable.ListMap
@@ -33,7 +34,7 @@ class ListMapOperationsUnitTest extends AnyFlatSpec with Matchers {
     )
     assert(newListMap.head == ("Canada" -> "Ottawa"))
   }
-  
+
   "+ operator" should "update the value of an existing key in the ListMap" in {
     assert(countryCapitals("India") == "Delhi")
     val newListMap = countryCapitals + ("India" -> "New Delhi")

--- a/scala-core-collection-2/src/test/scala-2/com/baeldung/scala/commoncollections/ListSetOperationsUnitTest.scala
+++ b/scala-core-collection-2/src/test/scala-2/com/baeldung/scala/commoncollections/ListSetOperationsUnitTest.scala
@@ -1,5 +1,6 @@
 package com.baeldung.scala.commoncollections
 
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 import scala.collection.immutable.ListSet

--- a/scala-core-collection-2/src/test/scala-2/com/baeldung/scala/commoncollections/ScalaCollectionsUnitTest.scala
+++ b/scala-core-collection-2/src/test/scala-2/com/baeldung/scala/commoncollections/ScalaCollectionsUnitTest.scala
@@ -1,85 +1,86 @@
 package com.baeldung.scala.commoncollections
 
-import org.scalatest.{Matchers, _}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 class ScalaCollectionsUnitTest extends AnyFlatSpec with Matchers {
 
   "Scala list" should "concatenate using ::: operator" in {
-    //given
+    // given
     val list1 = List(1, 2)
     val list2 = List(3, 4)
 
-    //when
+    // when
     val res = list1 ::: list2
 
-    //then
+    // then
     res shouldBe List(1, 2, 3, 4)
   }
 
   it should "create a list will all identical elements using fill method" in {
-    //when and then
+    // when and then
     List.fill(3)(100) shouldBe List(100, 100, 100)
   }
 
   it should "reverse should create a reverse all elements of the list" in {
-    //given
+    // given
     val list = List(1, 2, 3, 4)
 
-    //when and then
+    // when and then
     list.reverse shouldBe List(4, 3, 2, 1)
   }
 
   "Scala set" should "return head of the set when .head method invoked" in {
-    //given
+    // given
     val set = Set(1, 2, 3, 4)
 
-    //when and then
+    // when and then
     set.head shouldBe 1
   }
 
   it should "return all element of set except head when .tail method invoked" in {
-    //given
+    // given
     val set = Set(1, 2, 3, 4)
 
-    //when and then
+    // when and then
     set.tail shouldBe Set(2, 3, 4)
   }
 
   "Maps" should "return all keys from the map when .keys method invoked" in {
-    //given
+    // given
     val map = Map(1 -> "a", 2 -> "b")
 
-    //when and then
+    // when and then
     map.keys shouldBe Set(1, 2)
   }
 
   it should "return all values from the map when .values invoked" in {
-    //given
+    // given
     val map = Map(1 -> "a", 2 -> "b")
 
-    //when and then
+    // when and then
     map.values.toList shouldBe List("a", "b")
   }
 
   it should "return None if the key is not found in map when .get method invoked" in {
-    //given
+    // given
     val map = Map(1 -> "a", 2 -> "b")
 
-    //when
+    // when
     val res = map.get(-1)
 
-    //then
+    // then
     res.isEmpty shouldBe true
   }
 
   it should "return value if the key is found in map using .get method" in {
-    //given
+    // given
     val map = Map(1 -> "a", 2 -> "b")
 
-    //when
+    // when
     val res = map.get(1)
 
-    //then
+    // then
     res shouldBe Some("a")
   }
 }

--- a/scala-core-collection-2/src/test/scala-2/com/baeldung/scala/flattening/FlattenerSpec.scala
+++ b/scala-core-collection-2/src/test/scala-2/com/baeldung/scala/flattening/FlattenerSpec.scala
@@ -1,5 +1,7 @@
 package com.baeldung.scala.flattening
 
+import org.scalatest.wordspec.AnyWordSpec
+
 import scala.collection.immutable.Queue
 
 class FlattenerSpec extends AnyWordSpec {

--- a/scala-core-collection-2/src/test/scala-2/com/baeldung/scala/lazylists/SimpleLazyListSpec.scala
+++ b/scala-core-collection-2/src/test/scala-2/com/baeldung/scala/lazylists/SimpleLazyListSpec.scala
@@ -3,15 +3,15 @@ package com.baedung.scala.lazylists
 import com.baeldung.scala.lazylists.{#:@:, SLNil, SimpleLazyList}
 import org.scalatest.wordspec.AnyWordSpec
 
-
 class SimpleLazyListSpec extends AnyWordSpec {
   "A list" should {
     "Allow the creation of a one Element list" in {
       assertResult(5)((5 :: SLNil).head)
     }
     "A Simple Lazy List can represent a Fibonacci sequence without throwing a Stack Overflow" in {
-        def fibonacci(current: Int = 0, next: Int = 1): SimpleLazyList[Int] = #:@:(current, fibonacci(next, current + next))
-        assertResult(8)(fibonacci().!!(7))
+      def fibonacci(current: Int = 0, next: Int = 1): SimpleLazyList[Int] =
+        #:@:(current, fibonacci(next, current + next))
+      assertResult(8)(fibonacci().!!(7))
     }
     "The head of the Simple Lazy List is strict" in {
       var side = "No side effect"
@@ -22,15 +22,16 @@ class SimpleLazyListSpec extends AnyWordSpec {
         },
         SLNil
       )
+      assertResult("No side effect")(side)
+      assertResult("Side effect")(list.head)
       assertResult("Side effect")(side)
     }
     "The head of a Scala Lazy List is lazy" in {
       var side = "No side effect"
-      val list =
-        {
-          side = "Side effect"
-          side
-        } #:: LazyList.empty
+      val list = {
+        side = "Side effect"
+        side
+      } #:: LazyList.empty
       assertResult("No side effect")(side)
       list.map(x => {
         side = "Another side effect"

--- a/scala-core-collection-2/src/test/scala-2/com/baeldung/scala/lazylists/SimpleListSpec.scala
+++ b/scala-core-collection-2/src/test/scala-2/com/baeldung/scala/lazylists/SimpleListSpec.scala
@@ -10,7 +10,8 @@ class SimpleListSpec extends AnyWordSpec {
     }
     "Throw and Stack Overflow Exception if used to define a Fibonacci sequence" in {
       intercept[StackOverflowError] {
-        def fibonacci(current: Int = 0, next: Int = 1): SimpleList[Int] = :@:(current, fibonacci(next, current + 1))
+        def fibonacci(current: Int = 0, next: Int = 1): SimpleList[Int] =
+          :@:(current, fibonacci(next, current + 1))
         assertResult(8)(fibonacci().!!(7))
       }
     }


### PR DESCRIPTION
## Summary
- Add unit tests to demonstrate ArrayBuffer
- Enable build for the module
- Add missing import statements from some of the unit test files
- Fix style check issues and broken unit tests in the module

## JIRA
[SCALA-208](https://jira.baeldung.com/browse/SCALA-208)