### PR TITLE
Ignoring the Requests integration test due to issues with thirdparty service

### DIFF
--- a/scala-libraries-2/src/it/scala-2/com/baeldung/requests/RequestsScalaHttpClientLiveTest.scala
+++ b/scala-libraries-2/src/it/scala-2/com/baeldung/requests/RequestsScalaHttpClientLiveTest.scala
@@ -3,9 +3,12 @@ package com.baeldung.requests
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.wordspec.AnyWordSpec
 import requests.Response
+import org.scalatest.Ignore
 
 import java.io.{FileOutputStream, PrintWriter}
 
+// Temporarily ignoring this test due to timeout errors from httpbin.org. The APIs are timing out and hence test is failing
+@Ignore
 class RequestsScalaHttpClientLiveTest
   extends AnyWordSpec
   with BeforeAndAfterAll {


### PR DESCRIPTION
 httpbin.org is timing out or taking too much time to respond. This causes the integration test to fail.