### PR TITLE
SCALA-548: Escape double quote using metacharacter in interpolation

### DIFF
--- a/scala-strings/src/test/scala-2/com/baeldung/scala/strings/interpolation/strings/interpolation/EscapeUsingMetaCharUnitTest.scala
+++ b/scala-strings/src/test/scala-2/com/baeldung/scala/strings/interpolation/strings/interpolation/EscapeUsingMetaCharUnitTest.scala
@@ -1,0 +1,21 @@
+package com.baeldung.scala.strings.interpolation.strings.interpolation
+
+import org.scalatest.flatspec.AnyFlatSpec
+
+class InterpolationEscapesSpec extends AnyFlatSpec {
+
+  val DOUBLE_QUOTE: Char = '"'
+
+  "Escape using metachar in s-interpolation" should "include double quote character" in {
+    val actual: String = s"Hello, ${DOUBLE_QUOTE}world!${DOUBLE_QUOTE}"
+    val expected = "Hello, " + DOUBLE_QUOTE + "world!" + DOUBLE_QUOTE
+    assert(expected == actual)
+  }
+
+  "Escape using metachar in f-interpolation" should "include double quote character" in {
+    val actual: String = f"Hello, ${DOUBLE_QUOTE}world!${DOUBLE_QUOTE}"
+    val expected = "Hello, " + DOUBLE_QUOTE + "world!" + DOUBLE_QUOTE
+    assert(expected == actual)
+  }
+
+}


### PR DESCRIPTION
## Summary
Escape double quote using metachar in interpolations

## Jira
[SCALA-548](https://jira.baeldung.com/browse/SCALA-548)