### PR TITLE
SCALA-623 different ways to reverse lists

### DIFF
--- a/scala-core-8/src/main/scala-2/com/baeldung/scala/reverselists/ListReverser.scala
+++ b/scala-core-8/src/main/scala-2/com/baeldung/scala/reverselists/ListReverser.scala
@@ -2,9 +2,9 @@ package com.baeldung.scala.reverselists
 
 import scala.annotation.tailrec
 
-/**
- * Contains several implementations of methods to reverse sequences (SCALA-623).
- */
+/** Contains several implementations of methods to reverse sequences
+  * (SCALA-623).
+  */
 object ListReverser {
 
   /** Builds a sequence with the same elements as the argument, in reverse
@@ -17,7 +17,8 @@ object ListReverser {
     *   sequence with the input elements in reverse order
     */
   def naiveRecursiveReverse[T](xs: Seq[T]): Seq[T] = {
-    xs
+    if (xs.isEmpty) xs
+    else naiveRecursiveReverse(xs.drop(1)) :+ xs.head
   }
 
   /** Builds a sequence with the same elements as the argument, in reverse

--- a/scala-core-8/src/main/scala-2/com/baeldung/scala/reverselists/ListReverser.scala
+++ b/scala-core-8/src/main/scala-2/com/baeldung/scala/reverselists/ListReverser.scala
@@ -50,8 +50,7 @@ object ListReverser {
     * @return
     *   sequence with the input elements in reverse order
     */
-  def foldBasedReverse[T](xs: Seq[T]): Seq[T] = {
-    xs
-  }
+  def foldBasedReverse[T](xs: Seq[T]): Seq[T] =
+    xs.foldLeft(Seq.empty[T])((sequence, element) => element +: sequence)
 
 }

--- a/scala-core-8/src/main/scala-2/com/baeldung/scala/reverselists/ListReverser.scala
+++ b/scala-core-8/src/main/scala-2/com/baeldung/scala/reverselists/ListReverser.scala
@@ -16,10 +16,9 @@ object ListReverser {
     * @return
     *   sequence with the input elements in reverse order
     */
-  def naiveRecursiveReverse[T](xs: Seq[T]): Seq[T] = {
+  def naiveRecursiveReverse[T](xs: Seq[T]): Seq[T] =
     if (xs.isEmpty) xs
     else naiveRecursiveReverse(xs.drop(1)) :+ xs.head
-  }
 
   /** Builds a sequence with the same elements as the argument, in reverse
     * order. It uses a tail-recursive pattern, so the heap is safe.

--- a/scala-core-8/src/main/scala-2/com/baeldung/scala/reverselists/ListReverser.scala
+++ b/scala-core-8/src/main/scala-2/com/baeldung/scala/reverselists/ListReverser.scala
@@ -31,9 +31,13 @@ object ListReverser {
     * @return
     *   sequence with the input elements in reverse order
     */
-  @tailrec
   def tailRecursiveReverse[T](xs: Seq[T]): Seq[T] = {
-    tailRecursiveReverse(xs)
+    @tailrec
+    def aux(acc: Seq[T], sequence: Seq[T]): Seq[T] = {
+      if (sequence.isEmpty) acc
+      else aux(sequence.head +: acc, sequence.tail)
+    }
+    aux(Seq.empty[T], xs)
   }
 
   /** Builds a sequence with the same elements as the argument, in reverse

--- a/scala-core-8/src/main/scala-2/com/baeldung/scala/reverselists/ListReverser.scala
+++ b/scala-core-8/src/main/scala-2/com/baeldung/scala/reverselists/ListReverser.scala
@@ -1,0 +1,52 @@
+package com.baeldung.scala.reverselists
+
+import scala.annotation.tailrec
+
+/**
+ * Contains several implementations of methods to reverse sequences (SCALA-623).
+ */
+object ListReverser {
+
+  /** Builds a sequence with the same elements as the argument, in reverse
+    * order. It uses a simple recursion pattern, hence accumulating in the heap.
+    * @param xs
+    *   sequence to be reversed
+    * @tparam T
+    *   type of the elements of the sequence
+    * @return
+    *   sequence with the input elements in reverse order
+    */
+  def naiveRecursiveReverse[T](xs: Seq[T]): Seq[T] = {
+    xs
+  }
+
+  /** Builds a sequence with the same elements as the argument, in reverse
+    * order. It uses a tail-recursive pattern, so the heap is safe.
+    *
+    * @param xs
+    *   sequence to be reversed
+    * @tparam T
+    *   type of the elements of the sequence
+    * @return
+    *   sequence with the input elements in reverse order
+    */
+  @tailrec
+  def tailRecursiveReverse[T](xs: Seq[T]): Seq[T] = {
+    tailRecursiveReverse(xs)
+  }
+
+  /** Builds a sequence with the same elements as the argument, in reverse
+    * order. It uses the fold operation, thus enforcing functional principles.
+    *
+    * @param xs
+    *   sequence to be reversed
+    * @tparam T
+    *   type of the elements of the sequence
+    * @return
+    *   sequence with the input elements in reverse order
+    */
+  def foldBasedReverse[T](xs: Seq[T]): Seq[T] = {
+    xs
+  }
+
+}

--- a/scala-core-8/src/main/scala-2/com/baeldung/scala/reverselists/ListReverser.scala
+++ b/scala-core-8/src/main/scala-2/com/baeldung/scala/reverselists/ListReverser.scala
@@ -32,10 +32,10 @@ object ListReverser {
     */
   def tailRecursiveReverse[T](xs: Seq[T]): Seq[T] = {
     @tailrec
-    def aux(acc: Seq[T], sequence: Seq[T]): Seq[T] = {
+    def aux(acc: Seq[T], sequence: Seq[T]): Seq[T] =
       if (sequence.isEmpty) acc
       else aux(sequence.head +: acc, sequence.tail)
-    }
+
     aux(Seq.empty[T], xs)
   }
 

--- a/scala-core-8/src/test/scala-2/com/baeldung/scala/reverselists/ListReverserSpec.scala
+++ b/scala-core-8/src/test/scala-2/com/baeldung/scala/reverselists/ListReverserSpec.scala
@@ -17,7 +17,7 @@ class ListReverserSpec extends AnyWordSpec with BeforeAndAfterEach {
   }
 
   def testReverseBigList(f: Seq[_] => Seq[_]): Assertion = {
-    val n = 1_000_000
+    val n = 100_000
     val vector: Vector[String] =
       (0 to n).foldLeft(Vector.empty[String])((v, _) =>
         v.appended(Random.nextString(1000))
@@ -36,7 +36,7 @@ class ListReverserSpec extends AnyWordSpec with BeforeAndAfterEach {
     }
 
     "exhaust memory with big lists" in {
-//      assertThrows[StackOverflowError](testReverseBigList(reversingFunction))
+      assertThrows[StackOverflowError](testReverseBigList(reversingFunction))
     }
   }
 

--- a/scala-core-8/src/test/scala-2/com/baeldung/scala/reverselists/ListReverserSpec.scala
+++ b/scala-core-8/src/test/scala-2/com/baeldung/scala/reverselists/ListReverserSpec.scala
@@ -51,4 +51,16 @@ class ListReverserSpec extends AnyWordSpec with BeforeAndAfterEach {
       testReverseBigList(reversingFunction)
     }
   }
+
+  "The folding list reverser" should {
+    val reversingFunction: Seq[_] => Seq[_] = foldBasedReverse
+
+    "reverse small lists" in {
+      testReverseSmallList(reversingFunction)
+    }
+
+    "handle big lists" in {
+      testReverseBigList(reversingFunction)
+    }
+  }
 }

--- a/scala-core-8/src/test/scala-2/com/baeldung/scala/reverselists/ListReverserSpec.scala
+++ b/scala-core-8/src/test/scala-2/com/baeldung/scala/reverselists/ListReverserSpec.scala
@@ -1,0 +1,54 @@
+package com.baeldung.scala.reverselists
+
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.{Assertion, BeforeAndAfterEach}
+
+import scala.util.Random
+
+class ListReverserSpec extends AnyWordSpec with BeforeAndAfterEach {
+
+  import ListReverser._
+
+  def testReverseSmallList(f: Seq[_] => Seq[_]): Assertion = {
+    val list = List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    val expectedReversedList = List(10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+    val actualReversedList = f(list)
+    assertResult(expectedReversedList)(actualReversedList)
+  }
+
+  def testReverseBigList(f: Seq[_] => Seq[_]): Assertion = {
+    val n = 1_000_000
+    val vector: Vector[String] =
+      (0 to n).foldLeft(Vector.empty[String])((v, _) =>
+        v.appended(Random.nextString(1000))
+      )
+    val expectedFirstElement: String = vector.last
+    val actualFirstElement: String =
+      f(vector).head.asInstanceOf[String]
+    assertResult(expectedFirstElement)(actualFirstElement)
+  }
+
+  "The naive list reverser" should {
+    val reversingFunction: Seq[_] => Seq[_] = naiveRecursiveReverse
+
+    "reverse small lists" in {
+      testReverseSmallList(reversingFunction)
+    }
+
+    "exhaust memory with big lists" in {
+//      assertThrows[StackOverflowError](testReverseBigList(reversingFunction))
+    }
+  }
+
+  "The tail-recursive list reverser" should {
+    val reversingFunction: Seq[_] => Seq[_] = tailRecursiveReverse
+
+    "reverse small lists" in {
+      testReverseSmallList(reversingFunction)
+    }
+
+    "handle big lists" in {
+      testReverseBigList(reversingFunction)
+    }
+  }
+}


### PR DESCRIPTION
Three different ways to reverse sequences.

NB: The unit tests are designed to make one of them produce a _stack overflow_ error. If the JVM running the test is configured with a huge a mount of memory, the error condition won't happen and the test will fail.