### PR TITLE
Fixes error in SequenceApp.scala

### DIFF
--- a/cats-effects/src/main/scala/com/baeldung/scala/catseffects/SequenceApp.scala
+++ b/cats-effects/src/main/scala/com/baeldung/scala/catseffects/SequenceApp.scala
@@ -12,5 +12,5 @@ object SequenceApp extends IOApp {
     sequenceAllTasks.map(_.mkString(", ")).flatMap(putStr)
 
   override def run(args: List[String]): IO[ExitCode] =
-    sequenceAllTasks.as(ExitCode.Success)
+    printTaskSequence.as(ExitCode.Success)
 }


### PR DESCRIPTION
The old version does not run printTaskSequence. That way nothing is printed.
This error is also on the article site https://www.baeldung.com/scala/cats-effects-intro#conclusion (the link should also not be #conclusion but #2-basic-combinators